### PR TITLE
Support for HMI-1 (800 W Inverter)

### DIFF
--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -122,8 +122,8 @@ function cleanAndValidate(config: Config): void {
       // Remove colons from MAC address and convert to lowercase
       device.mac = device.mac.trim().replace(/:/g, '').toLowerCase();
       device.type = device.type.trim().toUpperCase() as DeviceTypeIdentifier;
-      if (device.device_id.length < 22 || device.device_id.length > 24) {
-        throw new Error('Device ID must be between 22 and 24 characters long');
+      if (device.device_id.length === 12 || (device.device_id.length < 22 || device.device_id.length > 24)) {
+        throw new Error('Device ID must be between 22 and 24 or exactly 12 characters long');
       }
       if (!/^[0-9A-Fa-f]{12}$/.test(device.mac)) {
         throw new Error('MAC address must be a 12-character hexadecimal string');

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -8,7 +8,7 @@ import { HealthServer } from './health';
 
 const deviceGenerations = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 50] as const;
 type DeviceGen = typeof deviceGenerations[number];
-const deviceTypes = ["A", "B", "D", "E", "F", "G", "J", "K"] as const;
+const deviceTypes = ["A", "B", "D", "E", "F", "G", "J", "K", "I"] as const;
 type DeviceType = typeof deviceTypes[number];
 type DeviceTypeIdentifier = `HM${DeviceType}-${DeviceGen}`;
 const knownDeviceTypes: DeviceTypeIdentifier[] = deviceGenerations.flatMap(gen => deviceTypes.map(type => `HM${type}-${gen}` satisfies DeviceTypeIdentifier));


### PR DESCRIPTION
I tried to add support for HMI-1 devices (Marstek MST-MI0800W) and added a new device type `I` (maybe like in "Inverter")

Since the `devid` returned by hame API contains the same value as the `mac` property it is only 12 characters long for these devices.

I haven't yet verified if this is working correctly. The initialization works and both my devices are listed under `Configured devices` when executing `npm start`, but I haven't found a possibility to test my changes in my home assistant installation.

I'm curious how the certs including secret key are extracted for a40nr6osvmmaw-ats.iot.eu-central-1.amazonaws.com
These seem to be required for docker image build right?