### PR TITLE
Support for Marstek Jupiter E

### DIFF
--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -8,7 +8,7 @@ import { HealthServer } from './health';
 
 const deviceGenerations = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 50] as const;
 type DeviceGen = typeof deviceGenerations[number];
-const deviceTypes = ["A", "B", "D", "E", "F", "G", "J", "K", "I"] as const;
+const deviceTypes = ["A", "B", "D", "E", "F", "G", "J", "K", "I", "N"] as const;
 type DeviceType = typeof deviceTypes[number];
 type DeviceTypeIdentifier = `HM${DeviceType}-${DeviceGen}`;
 const knownDeviceTypes: DeviceTypeIdentifier[] = deviceGenerations.flatMap(gen => deviceTypes.map(type => `HM${type}-${gen}` satisfies DeviceTypeIdentifier));


### PR DESCRIPTION
added  "N" option for **Marstek Jupiter E**. (Model: _MST-HIE5-0800_) with 5120 Wh
The Jupiter is noted as **HMN-1**. At least thats for my Version. Because i could no longer access the official hame website, i had to find out the `device ID` in another way. To do this, I changed the DNS request of the device to one of my local devices and extracted the ID from it.
Anyway, with the “inverse_forwarding” a mqtt request to` hame_energy/HMN-1/App/xxxxxxx/ctrl` with `cd=1` works and gives me a JSON response to `hame_energy/HMN-1/device/xxxxxxx/ctrl`, which I now have to parse. for this I am currently trying my hand at [hm2mqtt](https://github.com/tomquist/hm2mqtt) 