### PR TITLE
Expose log level option

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ docker run -d \
   -v "$(pwd)/config:/app/config" \
   ghcr.io/tomquist/hame-relay:main
 ```
+Set `LOG_LEVEL` to control verbosity, e.g. `-e LOG_LEVEL=debug`.
 
 ### Option 2: Using Docker Compose
 
@@ -143,7 +144,10 @@ services:
     restart: unless-stopped
     volumes:
       - ./config:/app/config
+    environment:
+      - LOG_LEVEL=debug
 ```
+Set `LOG_LEVEL` to control verbosity.
 
 4. Start the container:
 ```bash
@@ -212,6 +216,7 @@ The add-on will automatically use your Home Assistant MQTT settings if configure
 - `username`: Your Hame account email address. When provided along with password, 
   the tool will automatically fetch device information from the Hame API and display it in the logs.
 - `password`: Your Hame account password. Required when using automatic device information retrieval.
+- `log_level`: Adjust log verbosity (`trace`, `debug`, `info`, `warn`, `error`, `fatal`).
 
 ## Development
 

--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -17,6 +17,7 @@ watchdog: "http://[HOST]:[PORT:8080]/health"
 options:
   inverse_forwarding: false
   default_broker_id: hame-2024
+  log_level: info
   devices:
     - device_id: "24-digit-device-id"
       mac: "maccaddresswithoutcolons"
@@ -25,6 +26,7 @@ schema:
   mqtt_uri: str?
   inverse_forwarding: bool?
   default_broker_id: str?
+  log_level: list(trace|debug|info|warn|error|fatal)?
   username: str?
   password: password?
   devices:

--- a/hassio-addon/run.sh
+++ b/hassio-addon/run.sh
@@ -43,6 +43,7 @@ bashio::log.info "Generating config file..."
 DEVICES=$(bashio::config 'devices' | jq -s '.')
 INVERSE_FORWARDING=$(bashio::config 'inverse_forwarding' "false")
 DEFAULT_BROKER_ID=$(bashio::config 'default_broker_id' "hame-2024")
+LOG_LEVEL=$(bashio::config 'log_level' "info")
 
 # Create base configuration
 CONFIG='{
@@ -109,5 +110,6 @@ else
 fi
 
 # Start the application
+export LOG_LEVEL
 bashio::log.info "Starting MQTT forwarder..."
 cd /app && node dist/forwarder.js


### PR DESCRIPTION
## Summary
- allow configuring log level in the Home Assistant addon
- document LOG_LEVEL usage in README

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6861c7720ed8832e8d6e529c4a792a7b