### PR TITLE
Add broker auto-selection based on device firmware

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ mkdir config
   "username": "your_hame_email@example.com",
   "password": "your_hame_password",
   "devices": [
-    { "device_id": "24-digit-device-id", "mac": "maccaddresswithoutcolons", "type": "HMA-1" }
+    { "device_id": "24-digit-device-id", "mac": "maccaddresswithoutcolons", "type": "HMA-1", "version": 0 }
   ]
 }
 ```
@@ -186,6 +186,7 @@ devices:
   - device_id: "0123456789abcdef01234567"
     mac: "01234567890a"
     type: "HMA-1"
+    version: 151
   - device_id: "0123456789abcdef01234567"
     mac: "01234567890a"
     type: "HMA-1"
@@ -206,6 +207,7 @@ The add-on will automatically use your Home Assistant MQTT settings if configure
   - `device_id`: Your device's 22 to 24-digit ID
   - `mac`: Your device's MAC address without colons
   - `type`: Your device's type (e.g. HMA-1, HMA-2, HMA-3 etc.)
+  - `version`: (optional) Firmware version used for automatic broker selection. Enter the number without any decimal point (e.g. firmware `226.1` becomes `226`)
   - `inverse_forwarding`: (optional) Override the global setting for the operation mode of this device
 
 ### Optional Configuration

--- a/config/brokers.json
+++ b/config/brokers.json
@@ -5,7 +5,17 @@
     "cert": "@../certs/hame-2024.crt",
     "key": "@../certs/hame-2024.key",
     "topic_prefix": "hame_energy/",
-    "client_id_prefix": "hm_"
+    "client_id_prefix": "hm_",
+    "min_versions": {
+      "HMA": 0,
+      "HMB": 0,
+      "HMF": 0,
+      "HMJ": 0,
+      "HMG": 0,
+      "HMM": 0,
+      "HMN": 0,
+      "JPLS": 0
+    }
   },
   "hame-2025": {
     "url": "@../certs/hame-2025-url",
@@ -15,6 +25,13 @@
     "topic_prefix": "marstek_energy/",
     "local_topic_prefix": "hame_energy/",
     "client_id_prefix": "mst_",
-    "topic_encryption_key": "@../certs/hame-2025-topic-encryption-key"
+    "topic_encryption_key": "@../certs/hame-2025-topic-encryption-key",
+    "min_versions": {
+      "HMA": 226,
+      "HMF": 226,
+      "HMJ": 108,
+      "HMK": 226,
+      "HMG": 153
+    }
   }
 }

--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -22,6 +22,7 @@ options:
     - device_id: "24-digit-device-id"
       mac: "maccaddresswithoutcolons"
       type: "HMA-1"
+      version: 0
 schema:
   mqtt_uri: str?
   inverse_forwarding: bool?
@@ -33,4 +34,5 @@ schema:
     - device_id: str
       mac: str
       type: str
+      version: int?
       inverse_forwarding: bool?

--- a/src/forwarder.ts
+++ b/src/forwarder.ts
@@ -711,6 +711,7 @@ async function start() {
       logger.info(`  Remote ID: ${device.remote_id}`);
       logger.info(`  MAC: ${device.mac}`);
       logger.info(`  Type: ${device.type}`);
+      logger.info(`  Version: ${device.version ?? 'Unknown'}`);
       logger.info(`  Broker: ${device.broker_id}`);
       logger.info(`  Inverse Forwarding: ${device.inverse_forwarding ?? config.inverse_forwarding ?? false}`);
       logger.info(`  Use Remote Topic ID: ${device.use_remote_topic_id ?? false}`);

--- a/src/hame_api.ts
+++ b/src/hame_api.ts
@@ -1,0 +1,87 @@
+import {createHash} from 'crypto';
+import fetch from 'node-fetch';
+import {logger} from './logger';
+
+export interface HameApiResponse {
+  code: string;
+  msg: string;
+  token?: string;
+  data: Array<{
+    devid: string;
+    name: string;
+    sn: string | null;
+    mac: string;
+    type: string;
+    access: string;
+    bluetooth_name: string;
+  }> | string;
+}
+
+export interface HameDeviceListResponse {
+  code: number;
+  msg: string;
+  data: Array<{
+    devid: string;
+    name: string;
+    mac: string;
+    type: string;
+    version: string;
+  }>;
+}
+
+export interface DeviceInfo {
+  devid: string;
+  name: string;
+  mac: string;
+  type: string;
+  version: string;
+}
+
+export class HameApi {
+  constructor(private readonly baseUrl: string = 'https://eu.hamedata.com') {}
+
+  private get headers() {
+    return {
+      'User-Agent': 'Dart/2.19 (dart:io)',
+    } as Record<string, string>;
+  }
+
+  async fetchDeviceToken(mailbox: string, password: string): Promise<HameApiResponse> {
+    const hashedPassword = createHash('md5').update(password).digest('hex');
+    const url = new URL('/app/Solar/v2_get_device.php', this.baseUrl);
+    url.searchParams.append('mailbox', mailbox);
+    url.searchParams.append('pwd', hashedPassword);
+
+    logger.info(`Fetching device token for ${mailbox}...`);
+    const resp = await fetch(url.toString(), { headers: this.headers });
+    const data: HameApiResponse = await resp.json();
+
+    if (data.code !== '2' || !data.token) {
+      throw new Error(`Unexpected API response code: ${data.code} - ${data.msg}`);
+    }
+
+    return data;
+  }
+
+  async fetchDeviceList(mailbox: string, token: string): Promise<HameDeviceListResponse> {
+    const url = new URL('/ems/api/v1/getDeviceList', this.baseUrl.replace(/\/$/, ''));
+    url.searchParams.append('mailbox', mailbox);
+    url.searchParams.append('token', token);
+
+    logger.info('Fetching device list...');
+    const resp = await fetch(url.toString(), { headers: this.headers });
+    const data: HameDeviceListResponse = await resp.json();
+
+    if (data.code !== 1) {
+      throw new Error(`Unexpected API response from device list: ${data.code} - ${data.msg}`);
+    }
+
+    return data;
+  }
+
+  async fetchDevices(mailbox: string, password: string): Promise<DeviceInfo[]> {
+    const tokenResp = await this.fetchDeviceToken(mailbox, password);
+    const list = await this.fetchDeviceList(mailbox, tokenResp.token!);
+    return list.data;
+  }
+}


### PR DESCRIPTION
## Summary
- extend broker configuration with `min_versions`
- fetch full device list via new API endpoint
- determine broker automatically based on device type and version
- expose device firmware version to HA config
- refactor Hame API logic into `hame_api.ts`
- return full token payload and document firmware version format

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686919f3e774832eb57e0bf077b0cfd7