### PR TITLE
Infer remote topic id from broker config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,8 @@ mkdir config
 - Remote broker settings are loaded from `brokers.json`. Each broker can specify
   `topic_prefix`, `client_id_prefix` (defaults to `hm_`), and an optional
   `topic_encryption_key` used to generate remote device identifiers.
+  `use_remote_topic_id_versions` can specify firmware versions that require
+  using the remote topic ID structure.
 
 **Getting Device Information:**
 - **Recommended**: If you provide `username` and `password`, the relay can fetch your device information automatically from the Hame API. Check the container logs to see the retrieved device details, then update your configuration with the actual values.

--- a/config/brokers.json
+++ b/config/brokers.json
@@ -26,6 +26,12 @@
     "local_topic_prefix": "hame_energy/",
     "client_id_prefix": "mst_",
     "topic_encryption_key": "@../certs/hame-2025-topic-encryption-key",
+    "use_remote_topic_id_versions": {
+      "HMA": [226],
+      "HMF": [226],
+      "HMK": [226],
+      "HMJ": [108]
+    },
     "min_versions": {
       "HMA": 226,
       "HMF": 226,


### PR DESCRIPTION
## Summary
- add `use_remote_topic_id_versions` map to broker config
- detect remote topic ID needs for special firmware
- document the new broker option

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686a554a7ec8832e960811a1d4f5632b