### PR TITLE
Clarify MQTT configuration feedback

### DIFF
--- a/docs/b2500.html
+++ b/docs/b2500.html
@@ -941,8 +941,11 @@ devices:
                     // Send command
                     await commandCharacteristic.writeValue(command);
                     
-                    log('MQTT configuration sent successfully');
-                    alert('MQTT configuration set successfully');
+                    log('MQTT configuration command sent to device; verify broker logs for connection');
+                    alert('MQTT configuration command sent to device.\n\n'
+                        + 'This only confirms the command was sent — check your MQTT broker logs to confirm the device connects. '
+                        + 'If the device is still reachable via WiFi through the app, the configuration did not take effect. '
+                        + 'Try again or use a different device (some devices have a buggy Bluetooth driver).');
                 } finally {
                     // Reset button state
                     setMqttButton.disabled = false;


### PR DESCRIPTION
## Summary
- Clarify MQTT configuration message to explain that a successful response only means the command was sent to the device
- Note that users must check MQTT broker logs for device connection and retry or use another device if WiFi access remains

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a57066b0d4832ea392b0a2c5f73f1c