### PR TITLE
feat: prefer credential device settings

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -217,17 +217,24 @@ async function start() {
           for (const apiDevice of apiDevices) {
             if (userDevicesMap.has(apiDevice.device_id)) {
               const userDevice = userDevicesMap.get(apiDevice.device_id)!;
-              if (!userDevice.type) {
-                userDevice.type = apiDevice.type;
-              }
-              if (!userDevice.name) {
-                userDevice.name = apiDevice.name;
-              }
-              if (!userDevice.mac) {
-                userDevice.mac = apiDevice.mac;
-              }
-              if (userDevice.version == null) {
-                userDevice.version = apiDevice.version;
+              const props: (keyof Device)[] = [
+                "type",
+                "name",
+                "mac",
+                "version",
+              ];
+              for (const prop of props) {
+                const apiVal = apiDevice[prop];
+                const cfgVal = userDevice[prop];
+                if (apiVal !== undefined) {
+                  if (cfgVal !== undefined && cfgVal !== apiVal) {
+                    logger.warn(
+                      `Device ${apiDevice.device_id} setting '${prop}' from config (` +
+                        `${cfgVal}) differs from credentials (${apiVal}). Using credentials value.`,
+                    );
+                  }
+                  (userDevice as any)[prop] = apiVal as never;
+                }
               }
             } else {
               config.devices.push(apiDevice);


### PR DESCRIPTION
## Summary
- allow API-provided device settings to override config values
- warn when config settings differ from credentials

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b1445c1ee8832eb226520ae24e1f3e