### PR TITLE
Adding additional name prefix to support Jupiter

### DIFF
--- a/docs/b2500.html
+++ b/docs/b2500.html
@@ -384,7 +384,8 @@ devices:
                 // Apply the name prefix filter
                 bluetoothDevice = await navigator.bluetooth.requestDevice({
                     filters: [
-                        { namePrefix: 'HM_B2500' }
+                        { namePrefix: 'HM_B2500' },
+                        { namePrefix: 'MST' }
                     ],
                     // Include our service as an optional service
                     optionalServices: [currentServiceUuid]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Expanded Web Bluetooth device discovery. In addition to previously supported devices, the app can now find and connect to devices whose names begin with “MST.” This improves pairing for users with newer or differently branded hardware while preserving existing behavior for HM_B2500 devices. No action is required; discovery works automatically during scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->