### PR TITLE
Include HMB device type in selectable inverse forwarding list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## [Next]
+- Fixed forwarding direction for HMB devices. (#96)
+
 ## [1.3.0] - 2025-10-03
 - **BREAKING**: Username and password are now required for Home Assistant addon
 - **BREAKING**: Removed manual device configuration from Home Assistant addon (devices are now automatically discovered via API)

--- a/src/main.ts
+++ b/src/main.ts
@@ -245,7 +245,7 @@ async function start() {
       // Set inverse forwarding based on device type and configuration
       if (device.inverse_forwarding === undefined) {
         const deviceType = device.type.toUpperCase();
-        const selectableTypes = ["HMA", "HMF", "HMK", "HMJ"];
+        const selectableTypes = ["HMA", "HMF", "HMK", "HMJ", "HMB"];
 
         if (selectableTypes.some((type) => deviceType.startsWith(type))) {
           // For selectable device types, check if device ID is in the list


### PR DESCRIPTION
## Summary
- add the HMB device type to the list of selectable inverse forwarding device prefixes

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2041dc81c832e8fcdbf0824c6eaa4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * HMB devices are now selectable for inverse forwarding when not configured, so they appear for manual selection alongside previously supported types.
* **Bug Fixes**
  * Corrected forwarding direction behavior for HMB devices to ensure routing and selection behave as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->