### PR TITLE
Include date in log timestamps

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -8,7 +8,7 @@ export const logger = pino({
         target: "pino-pretty",
         options: {
           colorize: false,
-          translateTime: "HH:MM:ss",
+          translateTime: "yyyy-mm-dd HH:MM:ss",
           ignore: "pid,hostname",
         },
       },


### PR DESCRIPTION
## Summary
- update the pino-pretty configuration to include the date in translated log timestamps

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e22c1e7fa0832e943a91c79a31deb5

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated log timestamps to include the full date (format changed from “HH:MM:ss” to “yyyy-mm-dd HH:MM:ss”).
  * Log entries now display both date and time for each message.
  * No changes to application features or user workflows.
  * Note: Any external tools or scripts that parse logs by timestamp format may need to accommodate the new format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->