### PR TITLE
Use yq to update add-on version in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -42,6 +42,12 @@ VERSION="$1"
 RELEASE_BRANCH="release/v${VERSION}"
 CURRENT_DATE=$(date +%Y-%m-%d)
 
+# Ensure required tools are available
+if ! command -v yq >/dev/null 2>&1; then
+    print_error "yq is required but not installed. Please install yq before running this script."
+    exit 1
+fi
+
 # Validate version format (semantic versioning)
 if ! [[ $VERSION =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
     print_error "Version must follow semantic versioning format (e.g., 1.2.3)"
@@ -111,8 +117,7 @@ git checkout -b "$RELEASE_BRANCH"
 
 # Update version in config.yaml
 print_info "Updating version in hassio-addon/config.yaml"
-sed -i.bak "s/version: \"next\"/version: \"$VERSION\"/" hassio-addon/config.yaml
-rm hassio-addon/config.yaml.bak
+yq eval --inplace ".version = \"${VERSION}\"" hassio-addon/config.yaml
 
 # Update CHANGELOG.md
 print_info "Updating CHANGELOG.md"


### PR DESCRIPTION
## Summary
- verify `yq` is available before running the release workflow
- use `yq` to set the Home Assistant add-on version in `hassio-addon/config.yaml`

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68ffd99cfa7c832e8fced051be77d78d

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release process reliability by implementing additional validation checks and improving version management during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->