### PR TITLE
Handle release merge conflict in release script

### DIFF
--- a/release.sh
+++ b/release.sh
@@ -143,7 +143,17 @@ git checkout main
 git pull origin main
 
 print_info "Merging release branch into main"
-git merge "$RELEASE_BRANCH" --no-ff -m "Merge release v${VERSION}"
+if ! git merge "$RELEASE_BRANCH" --no-ff -m "Merge release v${VERSION}"; then
+    if git status --short | grep -q "^UU hassio-addon/config.yaml"; then
+        print_warning "Merge conflict detected in hassio-addon/config.yaml. Using release branch version."
+        git checkout --theirs hassio-addon/config.yaml
+        git add hassio-addon/config.yaml
+        git commit --no-edit
+    else
+        print_error "Merge failed due to conflicts. Please resolve manually."
+        exit 1
+    fi
+fi
 
 # Create and push tag
 print_info "Creating tag ${VERSION}"


### PR DESCRIPTION
## Summary
- handle merge conflicts in hassio-addon/config.yaml during release merges
- automatically prefer the release branch version and keep the merge commit message
- fail with a clear error if other conflicts are encountered

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690f9837bdf8832ea2cc8d9660d4fc39)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release automation to intelligently handle merge conflicts, automatically resolving known scenarios while safely preventing unexpected issues from disrupting the release process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->