### PR TITLE
Improve incorrect credential error messaging

### DIFF
--- a/src/hame_api.ts
+++ b/src/hame_api.ts
@@ -187,6 +187,12 @@ export class HameApi {
 
       const data = (await resp.json()) as HameApiResponse;
 
+      if (data.code === "4") {
+        throw new Error(
+          `Incorrect password for ${mailbox}. Please double-check the credentials configured for the add-on and try again. (${data.code} - ${data.msg})`,
+        );
+      }
+
       if (data.code !== "2" || !data.token) {
         throw new Error(
           `Unexpected API response code: ${data.code} - ${data.msg}`,


### PR DESCRIPTION
## Summary
- provide a clearer error message when the Hame API reports an incorrect password during token retrieval

## Testing
- npm test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69170fa24af0832e8d904245740c69b5)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error messaging for incorrect password scenarios during authentication, providing clearer feedback when login attempts fail due to invalid credentials.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->