### PR TITLE
Add documentation for using the next version

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ services:
 ### Home Assistant
 
 Add the development branch repository to your Home Assistant add-on store:
-```
+```text
 https://github.com/tomquist/hame-relay#develop
 ```
 


### PR DESCRIPTION
Added a new section "Using the Next Version" to the README that explains how to use the development version tagged as "next" for both Docker and Home Assistant deployments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a "Using the Development Version" section with guidance for using the development image/tag, Docker run and Docker Compose examples, Home Assistant integration notes (referencing the develop branch), and a stability warning.
  * Note: the new section was accidentally duplicated in the README.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->