### PR TITLE
Docs: align README with Home Assistant Apps terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The easiest way to get started is with the Home Assistant app (part of Home Assi
 ### Installation
 
 1. Add this repository to your Home Assistant App Store:
-   ```
+   ```text
    https://github.com/tomquist/hame-relay
    ```
 


### PR DESCRIPTION
Updates README wording to match Home Assistant rename to Apps (formerly known as add-ons). Replaces user-facing mentions of "add-on" / "Add-on Store" with "app" / "App Store" in the Home Assistant quick-start sections, keeping everything else unchanged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README to reflect current product naming conventions throughout the documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->