### PR TITLE
fix: reduce remote MQTT retry storm

### DIFF
--- a/src/mqtt_forwarder.ts
+++ b/src/mqtt_forwarder.ts
@@ -115,6 +115,16 @@ export class MQTTForwarder {
       ...certs,
       protocol: "mqtts" as const,
       keepalive: 30,
+      // MQTT.js defaults to reconnecting every 1s. That's too aggressive when
+      // DNS resolution or upstream connectivity is flaky and can create a noisy
+      // retry/log storm on smaller systems.
+      reconnectPeriod: 30_000,
+      // Reduce the amount of time each failed attempt ties up resources before
+      // the next reconnect is scheduled.
+      connectTimeout: 10_000,
+      // Drop QoS 0 messages while the remote broker is unavailable instead of
+      // queueing them indefinitely in memory.
+      queueQoSZero: false,
       clientId: this.generateClientId(
         this.config.remote.client_id_prefix || "hm_",
       ),


### PR DESCRIPTION
## Summary
- reduce remote MQTT reconnect frequency from the MQTT.js default of 1s to 30s
- shorten the remote connect timeout to 10s so failed attempts release resources sooner
- disable QoS 0 offline queueing on the remote broker connection

## Why
When DNS resolution or upstream connectivity to the Hame AWS IoT endpoint is flaky, the remote broker client can fall into a noisy reconnect/error loop. On smaller Home Assistant systems that can create enough retry and log churn to noticeably hurt responsiveness.

This PR keeps the fix simple and uses built-in MQTT.js client options instead of custom reconnect logic.

## Testing
- `npm test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated MQTT remote broker connection configuration affecting reconnection timing, connection timeout duration, and QoS 0 message handling during broker unavailability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->