### PR TITLE
Warn loudly about inverse_forwarding=true and auto-close such issues

### DIFF
--- a/.github/workflows/close-inverse-forwarding-issues.yml
+++ b/.github/workflows/close-inverse-forwarding-issues.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.issue.state == 'open'
     steps:
-      - name: Detect inverse_forwarding: true and close
+      - name: "Detect inverse_forwarding: true and close"
         uses: actions/github-script@v7
         with:
           script: |

--- a/.github/workflows/close-inverse-forwarding-issues.yml
+++ b/.github/workflows/close-inverse-forwarding-issues.yml
@@ -33,8 +33,8 @@ jobs:
             //   inverse_forwarding: true
             //   'inverse_forwarding' is set to TRUE at the top level.
             const patterns = [
-              /["']?inverse_forwarding["']?\s*:\s*true\b/i,
-              /["']?inverse_forwarding["']?\s+is\s+set\s+to\s+true\b/i,
+              /["']?\binverse_forwarding\b["']?\s*:\s*true\b/i,
+              /["']?\binverse_forwarding\b["']?\s+is\s+set\s+to\s+true\b/i,
             ];
 
             const hit =

--- a/.github/workflows/close-inverse-forwarding-issues.yml
+++ b/.github/workflows/close-inverse-forwarding-issues.yml
@@ -19,18 +19,31 @@ jobs:
             const issue = context.payload.issue;
             const body = issue.body || '';
 
-            // Match the flag set to true in JSON, YAML, or the startup log line.
+            // Only consider content inside fenced code blocks. Issues that
+            // merely mention the flag in prose (e.g. "I tried setting
+            // inverse_forwarding: true and it broke") should not be auto-closed.
+            // The bug template renders the Configuration and Logs fields as
+            // fenced blocks, so the real cases we care about are still caught.
+            const fencedBlocks = body.match(/```[\s\S]*?```/g) || [];
+            const fencedText = fencedBlocks.join('\n');
+
+            // Match the flag set to true in JSON, YAML config, or in the
+            // startup warning banner emitted by src/main.ts.
             //   "inverse_forwarding": true
             //   inverse_forwarding: true
-            //   Global inverse_forwarding flag is true
+            //   'inverse_forwarding' is set to TRUE at the top level.
             const patterns = [
               /["']?inverse_forwarding["']?\s*:\s*true\b/i,
-              /\binverse_forwarding\s+flag\s+is\s+true\b/i,
+              /["']?inverse_forwarding["']?\s+is\s+set\s+to\s+true\b/i,
             ];
 
-            const hit = patterns.some((re) => re.test(body));
+            const hit =
+              fencedText.length > 0 &&
+              patterns.some((re) => re.test(fencedText));
             if (!hit) {
-              core.info('No inverse_forwarding: true detected.');
+              core.info(
+                'No inverse_forwarding: true detected in fenced code blocks.',
+              );
               return;
             }
 

--- a/.github/workflows/close-inverse-forwarding-issues.yml
+++ b/.github/workflows/close-inverse-forwarding-issues.yml
@@ -1,0 +1,96 @@
+name: Auto-close inverse_forwarding issues
+
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    if: github.event.issue.state == 'open'
+    steps:
+      - name: Detect inverse_forwarding: true and close
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issue = context.payload.issue;
+            const body = issue.body || '';
+
+            // Match the flag set to true in JSON, YAML, or the startup log line.
+            //   "inverse_forwarding": true
+            //   inverse_forwarding: true
+            //   Global inverse_forwarding flag is true
+            const patterns = [
+              /["']?inverse_forwarding["']?\s*:\s*true\b/i,
+              /\binverse_forwarding\s+flag\s+is\s+true\b/i,
+            ];
+
+            const hit = patterns.some((re) => re.test(body));
+            if (!hit) {
+              core.info('No inverse_forwarding: true detected.');
+              return;
+            }
+
+            const marker = '<!-- auto-close: inverse_forwarding -->';
+
+            const existing = await github.paginate(
+              github.rest.issues.listComments,
+              {
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                per_page: 100,
+              },
+            );
+            const alreadyCommented = existing.some((c) =>
+              (c.body || '').includes(marker),
+            );
+
+            if (!alreadyCommented) {
+              const comment = [
+                marker,
+                "Thanks for the report. This issue is being closed automatically because the configuration contains `inverse_forwarding: true`.",
+                "",
+                "As called out in the [README](https://github.com/tomquist/hame-relay#advanced-docker-configuration) and in the startup logs, the top-level `inverse_forwarding` flag flips the auto-detected forwarding direction for **every** device and almost always breaks communication between your devices and the Marstek cloud app. Bug reports with this flag enabled are closed without investigation.",
+                "",
+                "**What to do:**",
+                "1. Set `inverse_forwarding` to `false` (or remove it).",
+                "2. If you previously ran Hame Relay against a B2500 in *Mode 2* and need to keep that behavior for specific devices, list those device IDs in `inverse_forwarding_device_ids` instead.",
+                "3. Restart Hame Relay and confirm the problem still reproduces.",
+                "",
+                "If the issue still reproduces with `inverse_forwarding: false`, please open a new issue (or comment here asking for it to be reopened) including fresh debug logs.",
+              ].join('\n');
+
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                body: comment,
+              });
+            } else {
+              core.info('Auto-close comment already present, skipping.');
+            }
+
+            if (issue.state === 'open') {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                state: 'closed',
+                state_reason: 'not_planned',
+              });
+            }
+
+            try {
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issue.number,
+                labels: ['invalid-config'],
+              });
+            } catch (err) {
+              core.info(`Could not add label: ${err.message}`);
+            }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 - Removed rate limiting of outbound messages forwarded from local to Cloud
 - Fixed Venus series devices (VNSE3, VNSA, VNSD) not responding to control requests on firmware versions 123–138 by lowering the Venus encrypted-topic firmware threshold from 139 to 123 (#164)
 
-
 ## [1.3.5] - 2026-05-15
 - Support Marstek HME cloud-managed placeholder devices (AstraMeter synthetic MAC): derive `remote_id` from topic encryption, default missing API version to 1, disable inverse forwarding for that MAC pattern, and register HME in broker `min_versions`.
 

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ docker compose up -d
 
 The Docker version supports additional configuration options not available in the Home Assistant app.
 
-**Warning**: Do not enable `inverse_forwarding` unless you absolutely know what you're doing. Bug reports with this setting enabled will be closed immediately.
+**Warning**: Do not enable the top-level `inverse_forwarding` flag. It flips the auto-detected forwarding direction for *every* device and almost always breaks communication between your devices and the cloud app. If you previously ran Hame Relay against a B2500 in Mode 2 and need to keep that behavior for specific devices, leave `inverse_forwarding` set to `false` and list those device IDs in `inverse_forwarding_device_ids` instead. Bug reports with `inverse_forwarding: true` will be closed immediately without investigation.
 
 ```json
 {

--- a/src/main.ts
+++ b/src/main.ts
@@ -281,9 +281,40 @@ async function start() {
 
     // Apply global inverse_forwarding flip if enabled
     if (config.inverse_forwarding === true) {
-      logger.info(
-        "Global inverse_forwarding flag is true - flipping all device settings",
+      const banner =
+        "============================================================";
+      logger.warn(banner);
+      logger.warn(
+        "WARNING: 'inverse_forwarding' is set to TRUE at the top level.",
       );
+      logger.warn(
+        "This flag flips the auto-detected forwarding direction for ALL of",
+      );
+      logger.warn(
+        "your devices and is almost never what you want. In practice, leaving",
+      );
+      logger.warn(
+        "it enabled breaks communication between your device and the cloud app.",
+      );
+      logger.warn("Set 'inverse_forwarding' to false.");
+      logger.warn("");
+      logger.warn(
+        "If you previously ran Hame Relay against a B2500 in Mode 2 and need",
+      );
+      logger.warn(
+        "to keep that behavior for specific devices, list those device IDs in",
+      );
+      logger.warn(
+        "'inverse_forwarding_device_ids' instead of using the global flag.",
+      );
+      logger.warn("");
+      logger.warn(
+        "Issues submitted with 'inverse_forwarding: true' will be closed",
+      );
+      logger.warn(
+        "immediately without investigation. See the README for details.",
+      );
+      logger.warn(banner);
       for (const device of devicesConfig.devices) {
         const originalValue = device.inverse_forwarding;
         device.inverse_forwarding = !device.inverse_forwarding;


### PR DESCRIPTION
## Summary

Users keep filing bug reports with the top-level `inverse_forwarding` flag set to `true`, even though the README warns against it. This PR tries to stop that at both ends:

- **Loud startup warning.** When `inverse_forwarding: true` is set globally, `src/main.ts` now prints a multi-line `WARN` banner explaining that the flag flips the auto-detected forwarding direction for every device, that it almost always breaks communication with the Marstek cloud app, that `inverse_forwarding_device_ids` is the right knob for the legacy B2500 Mode 2 use case, and that issues filed with the flag enabled will be closed without investigation. The flip behavior itself is unchanged.
- **README clarification.** The existing one-liner warning is expanded with the same guidance, so users who actually read it get the alternative (`inverse_forwarding_device_ids`) up front.
- **Auto-close workflow.** A new `.github/workflows/close-inverse-forwarding-issues.yml` runs on `issues: opened/edited/reopened`. It scans the issue body for `inverse_forwarding: true` in JSON, YAML, or the startup log line (`Global inverse_forwarding flag is true`), and if found, posts a comment pointing the reporter at the fix, labels the issue `invalid-config`, and closes it as `not_planned`. A hidden marker comment prevents duplicate comments on edits/reopens.

## Test plan

- [x] `npm run lint` passes
- [x] `npm test` passes (102/102)
- [ ] Manual: start the relay with `"inverse_forwarding": true` and confirm the warn banner appears at startup
- [ ] Manual: open a test issue containing `"inverse_forwarding": true` and confirm the workflow comments, labels, and closes it
- [ ] Manual: open an unrelated test issue and confirm the workflow leaves it alone


---
_Generated by [Claude Code](https://claude.ai/code/session_01AtfUdX2AJ2efiwU9XkP8HS)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-closes issues that mention the legacy inverse_forwarding setting, posts a single explanatory marker comment, and attempts to add an explanatory label.

* **Documentation**
  * Multi-line startup warning banner explaining risks of the global inverse_forwarding flag and recommending per-device configuration.
  * Updated Docker guidance clarifying configuration recommendations.

* **Changelog**
  * Notes removal of rate limiting for outbound forwarded messages and a Venus-series device firmware compatibility fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->