### PR TITLE
Fix Venus devices not responding on firmware 123–138

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Fixed Venus series devices (VNSE3, VNSA, VNSD) not responding to control requests on firmware versions 123–138 by lowering the Venus encrypted-topic firmware threshold from 139 to 123 (#164)
 
 
 ## [1.3.5] - 2026-05-15

--- a/src/topic.test.ts
+++ b/src/topic.test.ts
@@ -242,6 +242,29 @@ describe("CommonHelper", () => {
       });
     });
 
+    describe("Venus series devices (VNSE3, VNSA, VNSD) - require firmware ≥ 123.0", () => {
+      test("should return true for VNSE3 with firmware 123.0", () => {
+        assert.strictEqual(CommonHelper.isSupportVid("VNSE3", "123.0"), true);
+      });
+
+      test("should return true for VNSA with firmware 135.0", () => {
+        assert.strictEqual(CommonHelper.isSupportVid("VNSA", "135.0"), true);
+      });
+
+      test("should return true for VNSD with firmware 135.0", () => {
+        assert.strictEqual(CommonHelper.isSupportVid("VNSD", "135.0"), true);
+      });
+
+      test("should return false for VNSE3 with firmware 122.9", () => {
+        assert.strictEqual(CommonHelper.isSupportVid("VNSE3", "122.9"), false);
+      });
+
+      test("should handle case insensitive Venus VID", () => {
+        assert.strictEqual(CommonHelper.isSupportVid("vnse3", "123.0"), true);
+        assert.strictEqual(CommonHelper.isSupportVid("vnsa", "122.9"), false);
+      });
+    });
+
     describe("Edge cases and error handling", () => {
       test("should return false for unknown VID", () => {
         assert.strictEqual(

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -368,9 +368,9 @@ class CommonHelper {
     }
 
     // All Venus series devices (VNSE3, VNSA, VNSD) support CommonHelper.cq encryption
-    // starting with firmware v139.
+    // starting with firmware v123.
     if (normalizedVid.startsWith("VNS")) {
-      return version >= 139.0;
+      return version >= 123.0;
     }
 
     return false;


### PR DESCRIPTION
## Summary

Venus series devices (VNSE3, VNSA, VNSD) on firmware versions 123–138 were not responding to control requests. Below the previous threshold, the relay derived the remote topic id via the plain topic-encryption fallback instead of the salt-based scheme the device actually uses, so control requests were published to a topic the device never subscribes to.

This lowers the Venus encrypted-topic firmware threshold in `CommonHelper.isSupportVid` from 139 to 123, so these devices use the salt-based topic scheme they subscribe to.

## Changes

- `src/topic.ts`: change the VNS firmware threshold from `139.0` to `123.0` (and update the adjacent comment).
- `src/topic.test.ts`: add an `isSupportVid` test block for the Venus series (VNSE3/VNSA/VNSD).
- `CHANGELOG.md`: add an unreleased entry.

## Testing

- `npm test` — all 112 tests pass
- `npm run lint` — clean

Fixes #164


---
_Generated by [Claude Code](https://claude.ai/code/session_01Wt9TQsPcqEvHs7Q1VPtz2a)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Venus series devices (VNSE3, VNSA, VNSD) now properly handle control requests on firmware versions 123–138.

* **Tests**
  * Added test coverage for Venus series device compatibility.

* **Chores**
  * Updated development dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->