### PR TITLE
Remove rate limiting logic from MQTT forwarder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Removed rate limiting of outbound messages forwarded from local to Cloud
 - Fixed Venus series devices (VNSE3, VNSA, VNSD) not responding to control requests on firmware versions 123–138 by lowering the Venus encrypted-topic firmware threshold from 139 to 123 (#164)
 
 

--- a/src/mqtt_forwarder.ts
+++ b/src/mqtt_forwarder.ts
@@ -9,16 +9,13 @@ export class MQTTForwarder {
   private remoteBroker!: mqtt.MqttClient;
   private readonly logger: typeof logger;
   private readonly MESSAGE_HISTORY_TIMEOUT = 1000; // 1 second timeout
-  private readonly RATE_LIMIT_INTERVAL = 59900; // Rate limit interval in milliseconds
   private readonly MESSAGE_CACHE_TIMEOUT = 1000; // 1 second timeout for message loop prevention
   private readonly INSTANCE_ID = createHash("md5")
     .update(`${Date.now()}-${Math.random()}`)
     .digest("hex")
     .substring(0, 8); // Unique ID for this instance
   private appMessageHistory: Map<string, number> = new Map(); // Store when App messages were forwarded
-  private rateLimitedMessages: Map<string, number> = new Map(); // Store when rate-limited messages were last forwarded
   private processedMessages: Map<string, number> = new Map(); // Store message hashes to prevent loops
-  private readonly RATE_LIMITED_CODES = [1, 13, 15, 16, 21, 26, 28, 30]; // Message codes to rate-limit (as numbers)
 
   constructor(private readonly config: ForwarderConfig) {
     this.logger = logger.child(
@@ -36,58 +33,6 @@ export class MQTTForwarder {
 
   public getConfigBroker(): MqttClient {
     return this.configBroker;
-  }
-
-  /**
-   * Checks if a message should be rate-limited based on its content
-   * @param message The message buffer to check
-   * @param deviceKey The unique device key
-   * @returns true if the message should be rate-limited, false otherwise
-   */
-  private shouldRateLimit(message: Buffer, deviceKey: string): boolean {
-    try {
-      const messageStr = message.toString();
-
-      // Extract the code number from the message
-      const codeMatch = messageStr.match(/cd=0*(\d+)/);
-      if (!codeMatch) {
-        return false;
-      }
-
-      // Convert the extracted code to a number
-      const messageCodeNum = parseInt(codeMatch[1], 10);
-
-      // Check if the code is in our rate-limited list
-      if (!this.RATE_LIMITED_CODES.includes(messageCodeNum)) {
-        return false;
-      }
-
-      // Create a unique key for this device and message type
-      const rateLimitKey = `${deviceKey}:${messageCodeNum}`;
-
-      // Check if we've seen this message recently
-      const lastSentTime = this.rateLimitedMessages.get(rateLimitKey);
-      const currentTime = Date.now();
-
-      if (
-        lastSentTime &&
-        currentTime - lastSentTime < this.RATE_LIMIT_INTERVAL
-      ) {
-        const remainingTime =
-          this.RATE_LIMIT_INTERVAL - (currentTime - lastSentTime);
-        this.logger.info(
-          `Devices configured with inverse_forwarding get rate limited. Rate limiting message with code cd=${messageCodeNum} for device ${deviceKey}. Please wait for ${remainingTime}ms before sending another message. Use inverse_forwarding=false to avoid rate limiting.`,
-        );
-        return true;
-      }
-
-      // Update the last sent time for this message type
-      this.rateLimitedMessages.set(rateLimitKey, currentTime);
-      return false;
-    } catch (error) {
-      this.logger.error(error, "Error in rate limiting logic");
-      return false; // On error, don't rate limit
-    }
   }
 
   private loadCertificates(): { ca: Buffer; cert: Buffer; key: Buffer } {
@@ -410,14 +355,6 @@ export class MQTTForwarder {
     } else {
       // This is an App message, record it in history
       this.appMessageHistory.set(deviceKey, Date.now());
-
-      // Apply rate limiting for messages going from local to Hame
-      if (
-        targetClient === this.remoteBroker &&
-        this.shouldRateLimit(message, deviceKey)
-      ) {
-        return;
-      }
     }
 
     // Get the target topic structure for this device on the target broker
@@ -462,13 +399,6 @@ export class MQTTForwarder {
     for (const [key, timestamp] of this.appMessageHistory.entries()) {
       if (now - timestamp > this.MESSAGE_HISTORY_TIMEOUT * 2) {
         this.appMessageHistory.delete(key);
-      }
-    }
-
-    // Clean up rate-limited message history
-    for (const [key, timestamp] of this.rateLimitedMessages.entries()) {
-      if (now - timestamp > this.RATE_LIMIT_INTERVAL * 2) {
-        this.rateLimitedMessages.delete(key);
       }
     }
 


### PR DESCRIPTION
## Summary
This PR removes the rate limiting functionality from the MQTT forwarder that was previously applied to messages with specific codes when forwarding from local to remote brokers.

## Key Changes
- Removed `RATE_LIMIT_INTERVAL` constant (59900ms)
- Removed `RATE_LIMITED_CODES` array containing message codes [1, 13, 15, 16, 21, 26, 28, 30]
- Removed `rateLimitedMessages` Map that tracked rate-limited message timestamps
- Removed `shouldRateLimit()` method that checked if messages should be rate-limited based on message code and device key
- Removed rate limiting check in the message forwarding logic that prevented messages from being sent to the remote broker within the rate limit interval
- Removed cleanup logic in the maintenance routine that purged expired rate-limited message history entries

## Implementation Details
The rate limiting was specifically applied when forwarding messages from the local broker to the remote broker (Hame). Messages with certain codes would be throttled to prevent sending more than one message per ~60 seconds per device. This functionality has been completely removed, allowing all messages to be forwarded without rate limiting restrictions.

https://claude.ai/code/session_012ErU8XkwywFTPD81gXqgES

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed rate-limiting on outbound local→cloud MQTT forwarding so messages are no longer throttled; loop prevention and message history handling remain intact.
* **Changelog**
  * Noted removal of outbound forwarding rate limits in the Next release notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->