### PR TITLE
Map Home Assistant log levels to Pino equivalents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [Next]
-- Fixed add-on failing to start when `log_level` was set to `warn`. The `log_level` option now uses Home Assistant's standard levels (`trace`, `debug`, `info`, `notice`, `warning`, `error`, `fatal`) and is mapped to the matching pino level internally (#142)
+- Fixed add-on failing to start when the log level was set to "warn" (#142)
 
 
 ## [1.4.0] - 2026-05-31

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Fixed add-on failing to start when `log_level` was set to `warn`. The `log_level` option now uses Home Assistant's standard levels (`trace`, `debug`, `info`, `notice`, `warning`, `error`, `fatal`) and is mapped to the matching pino level internally (#142)
 
 
 ## [1.4.0] - 2026-05-31

--- a/hassio-addon/config.yaml
+++ b/hassio-addon/config.yaml
@@ -20,7 +20,7 @@ schema:
   mqtt_uri: str?
   inverse_forwarding: bool?
   default_broker_id: list(hame-2024|hame-2025)?
-  log_level: list(trace|debug|info|warn|error|fatal)?
+  log_level: list(trace|debug|info|notice|warning|error|fatal)?
   username: str
   password: password
   inverse_forwarding_device_ids: str?

--- a/hassio-addon/run.sh
+++ b/hassio-addon/run.sh
@@ -55,6 +55,15 @@ INVERSE_FORWARDING=$(bashio::config 'inverse_forwarding' "false")
 DEFAULT_BROKER_ID=$(bashio::config 'default_broker_id' "hame-2024")
 LOG_LEVEL=$(bashio::config 'log_level' "info")
 
+# The "log_level" option is a reserved Home Assistant base image option that
+# only accepts HA's standard log levels (trace|debug|info|notice|warning|error|fatal).
+# Pino, used by the Node app, uses a slightly different set, so map the HA value
+# to the closest pino level.
+case "$LOG_LEVEL" in
+    warning) LOG_LEVEL="warn" ;;
+    notice) LOG_LEVEL="info" ;;
+esac
+
 bashio::log.info "Username and password found in configuration."
 
 # Build the config JSON with required fields


### PR DESCRIPTION
## Summary
Fixed an issue where the add-on would fail to start when certain log level options were selected. The problem was a mismatch between Home Assistant's standard log levels and the log levels supported by Pino (the logging library used by the Node app).

## Changes
- **config.yaml**: Updated the `log_level` schema to accept Home Assistant's standard log levels (`trace|debug|info|notice|warning|error|fatal`) instead of Pino's levels
- **run.sh**: Added a mapping function that converts Home Assistant log level values to their Pino equivalents:
  - `warning` → `warn`
  - `notice` → `info`
- **CHANGELOG.md**: Documented the fix

## Implementation Details
The fix uses a bash `case` statement to map the Home Assistant log level configuration to the appropriate Pino log level before passing it to the Node application. This allows users to configure the add-on using Home Assistant's standard log level options while maintaining compatibility with Pino's logging system.

https://claude.ai/code/session_01NGRMAvtMLvLAQurTwv8bTf

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Home Assistant add-on failing to start when log level is set to `"warn"`.

* **New Features**
  * Added support for `"notice"` as a valid log level option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->