### PR TITLE
Fix HME-2/3/4/5 broker migration thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Fixed HME-2/HME-3/HME-4/HME-5 meters (e.g. CT003) being placed on the 2025 broker at every firmware: they now migrate from the 2024 broker to the 2025 broker at the correct firmware (HME-3/HME-5 from fw ≥116, HME-2/HME-4 from fw ≥119), independently of the topic-encryption thresholds. Note: these broker-migration versions match the official app's behavior but are not yet confirmed against a live device (#145)
 - Fixed add-on failing to start when the log level was set to "warn" (#142)
 - Support HMI-2000 microinverter and default unknown/new device types to the 2025 broker with topic encryption. HMI-2000 uses the 2025 broker from fw ≥113 and topic encryption from fw ≥105, while other HMI inverters use ≥130 and ≥120 respectively. HMI-350 and HMI-500 always stay on the legacy broker with plaintext topics. Note: the HMI-2000 path is not yet confirmed against a live device (#158, #168)
 

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -41,8 +41,8 @@ switches to encrypted topic ids, and how forwarding is configured.
 | JPLS (`JPLS-NH`)    | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
 | HMD                 | hame-2025                   | 0     | —               | auto        | |
 | HME (base / other)  | hame-2025                   | 0     | —               | auto        | AstraMeter family |
-| HME-2, HME-4        | hame-2025                   | 122   | —               | auto        | AstraMeter family |
-| HME-3, HME-5        | hame-2025                   | 120   | —               | auto        | AstraMeter family |
+| HME-2, HME-4        | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family |
+| HME-3, HME-5        | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
 | TPM-CN              | hame-2025                   | 122   | —               | auto        | standalone identifier |
 | HMI (regular)       | hame-2025                   | 120   | —               | auto        | |
 | HMI-2000            | hame-2025                   | 105   | —               | auto        | 4-PV microinverter |

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -72,6 +72,9 @@ describe("device_matrix", () => {
       test("false below 120", () => {
         assert.strictEqual(supportsVid("HME-3", "119.9"), false);
         assert.strictEqual(supportsVid("HME-5", "115.0"), false);
+        // At the broker-migration fw (116) the meter moves to the 2025 broker
+        // but still does not encrypt topic ids (#145): thresholds are distinct.
+        assert.strictEqual(supportsVid("HME-3", "116"), false);
       });
     });
 
@@ -193,6 +196,18 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMN-1", 134), "hame-2024");
       assert.strictEqual(brokerForVersion("JPLS-8H", 134), "hame-2024");
       assert.strictEqual(brokerForVersion("JPLS-8H", 135), "hame-2025");
+    });
+
+    test("HME-2/HME-4: hame-2024 below 119, hame-2025 at/above (#145)", () => {
+      assert.strictEqual(brokerForVersion("HME-2", 118), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME-2", 119), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-4", 119), "hame-2025");
+    });
+
+    test("HME-3/HME-5: hame-2024 below 116, hame-2025 at/above (#145)", () => {
+      assert.strictEqual(brokerForVersion("HME-3", 115), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME-3", 116), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-5", 116), "hame-2025");
     });
 
     test("HMB: always hame-2024 (never migrates to the 2025 broker)", () => {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -96,6 +96,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     name: "HME-2/HME-4",
     matches: exact("HME-2", "HME-4"),
+    brokerRoutes: migrate2024to2025(119),
     vidSupportVersion: 122,
     inverse: "auto",
     astraMeter: true,
@@ -103,6 +104,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     name: "HME-3/HME-5",
     matches: exact("HME-3", "HME-5"),
+    brokerRoutes: migrate2024to2025(116),
     vidSupportVersion: 120,
     inverse: "auto",
     astraMeter: true,


### PR DESCRIPTION
## Summary
Fixed incorrect broker migration behavior for HME-2, HME-3, HME-4, and HME-5 meters (e.g. CT003). These devices were incorrectly always placed on the 2025 broker regardless of firmware version. They now properly migrate from the 2024 broker to the 2025 broker at the correct firmware versions.

## Key Changes
- **HME-2/HME-4**: Now migrate to hame-2025 broker at firmware ≥119 (previously always on 2025)
- **HME-3/HME-5**: Now migrate to hame-2025 broker at firmware ≥116 (previously always on 2025)
- Added `brokerRoutes` configuration to both device profiles using the `migrate2024to2025()` helper with the appropriate firmware thresholds
- Updated device matrix documentation to reflect the broker migration behavior
- Added comprehensive test coverage for both device groups with multiple firmware versions

## Implementation Details
- The broker migration thresholds are independent of the topic-encryption thresholds (which remain at fw ≥120 for HME-3/HME-5 and fw ≥122 for HME-2/HME-4)
- The migration versions match the official app's behavior but are not yet confirmed against live devices (see #145)
- Tests verify that `supportsVid()` correctly returns false for HME-3 at fw 116 (broker migration point but before encryption support)

https://claude.ai/code/session_01SMog35Y91wrPRF2ow5jkXU

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * HME-2/HME-4 meter devices now migrate from 2024 broker to 2025 broker at firmware version 119.
  * HME-3/HME-5 meter devices now migrate from 2024 broker to 2025 broker at firmware version 116.

* **Documentation**
  * Updated device support matrix and changelog with broker migration thresholds for HME meter types.

* **Tests**
  * Added test coverage for broker migration firmware thresholds and topic encryption behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->