### PR TITLE
Fix HMI broker routing regression (#173) and correct broker/VID thresholds for several device families

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 ## [Next]
+- Fixed HMI inverters (e.g. Marstek Saturn M800 / HMI-1) becoming unavailable after updating to 1.4.1: a regression placed all HMI devices on the 2025 broker regardless of firmware. Regular HMI now migrates from the 2024 broker to the 2025 broker at fw ≥129 (corrected from 130), HMI-2000 at fw ≥113, and HMI-350/HMI-500 stay on the legacy broker (#173)
+- Fixed HMK devices being placed on the 2025 broker at every firmware; they now migrate at fw ≥226 like HMA/HMF
+- Corrected several device broker / topic-encryption thresholds: TPM-CN uses topic encryption from fw ≥101 (was 122); base/other HME generations not in {HME-2/3/4/5} (e.g. HME-1) stay on the 2024 broker without topic encryption; Venus VNSD/VNSA (incl. VNSD2/VNSA2) migrate to the 2025 broker at fw ≥153 while VNSE3/VNSE4 stay on it unconditionally; HMD outdoor power stations route HMD-V/HMD-N to the 2025 broker, other HMD from fw >154, and never use topic encryption. Note: these thresholds are not yet confirmed against live devices
 
 
 ## [1.4.1] - 2026-06-01

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -33,7 +33,7 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMA                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
 | HMB                 | hame-2024                   | 230   | —               | selectable  | never offered the 2025 broker |
 | HMF                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
-| HMK                 | hame-2025                   | 230   | [226]           | selectable  | |
+| HMK                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
 | HMJ                 | hame-2024 → hame-2025 @108  | 116   | [108]           | selectable  | |
 | HMG                 | hame-2024 → hame-2025 @153  | 154   | —               | auto        | |
 | HMM                 | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -61,7 +61,7 @@ A device type is matched most-specific first:
    - `HMI-350`/`HMI-500` and `HMI-2000`, matched on a whole number token so ids
      like `HMI-3500`, `HMI-5000`, `HMI-12000` or `HMI-20001` fall through to the
      regular HMI profile.
-   - `HMD-V`/`HMD-N` (sub-types containing `V`/`N`) before base `HMD`.
+   - `HMD-V*`/`HMD-N*` (V6000 / M5000 sub-types) before base `HMD`.
    - `VNSD`/`VNSA` (incl. `VNSD2`/`VNSA2`) before base `VNS`.
 3. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
    `JPLS`, `HMD`, `HME`, `HMI`, `VNS`.

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -44,8 +44,8 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HME-2, HME-4        | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family |
 | HME-3, HME-5        | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
 | TPM-CN              | hame-2025                   | 122   | —               | auto        | standalone identifier |
-| HMI (regular)       | hame-2025                   | 120   | —               | auto        | |
-| HMI-2000            | hame-2025                   | 105   | —               | auto        | 4-PV microinverter |
+| HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | |
+| HMI-2000            | hame-2024 → hame-2025 @113  | 105   | —               | auto        | 4-PV microinverter |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", see #158 / #164 |
 | VNSE3, VNSA, VNSD   | hame-2025                   | 123   | —               | auto        | Venus series |
 | _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device |

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -39,15 +39,17 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMM                 | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
 | HMN                 | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
 | JPLS (`JPLS-NH`)    | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
-| HMD                 | hame-2025                   | 0     | —               | auto        | |
-| HME (base / other)  | hame-2025                   | 0     | —               | auto        | AstraMeter family |
+| HMD-V, HMD-N        | hame-2025                   | never | —               | auto        | V6000 / M5000 outdoor power |
+| HMD (other)         | hame-2024 → hame-2025 @155  | never | —               | auto        | outdoor power station |
+| HME (base / other)  | hame-2024                   | never | —               | auto        | AstraMeter family; non-2/3/4/5 |
 | HME-2, HME-4        | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family |
 | HME-3, HME-5        | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
-| TPM-CN              | hame-2025                   | 122   | —               | auto        | standalone identifier |
+| TPM-CN              | hame-2025                   | 101   | —               | auto        | standalone identifier |
 | HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | |
 | HMI-2000            | hame-2024 → hame-2025 @113  | 105   | —               | auto        | 4-PV microinverter |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", see #158 / #164 |
-| VNSE3, VNSA, VNSD   | hame-2025                   | 123   | —               | auto        | Venus series |
+| VNSD, VNSA (incl. VNSD2, VNSA2) | hame-2024 → hame-2025 @153 | 123 | —          | auto        | Venus series |
+| VNSE3, VNSE4        | hame-2025                   | 123   | —               | auto        | Venus series |
 | _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device |
 
 ## Matching precedence
@@ -55,9 +57,12 @@ switches to encrypted topic ids, and how forwarding is configured.
 A device type is matched most-specific first:
 
 1. Exact identifiers — `HME-2`/`HME-4`, `HME-3`/`HME-5`, `TPM-CN`.
-2. HMI model tokens — `HMI-350`/`HMI-500` and `HMI-2000`, matched on a whole
-   number token so ids like `HMI-3500`, `HMI-5000`, `HMI-12000` or `HMI-20001`
-   fall through to the regular HMI profile.
+2. Model-token rules (must precede their base prefix):
+   - `HMI-350`/`HMI-500` and `HMI-2000`, matched on a whole number token so ids
+     like `HMI-3500`, `HMI-5000`, `HMI-12000` or `HMI-20001` fall through to the
+     regular HMI profile.
+   - `HMD-V`/`HMD-N` (sub-types containing `V`/`N`) before base `HMD`.
+   - `VNSD`/`VNSA` (incl. `VNSD2`/`VNSA2`) before base `VNS`.
 3. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
    `JPLS`, `HMD`, `HME`, `HMI`, `VNS`.
 4. Unknown — assume a `hame-2025`, topic-encryption-capable device.

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -259,6 +259,9 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMD-N1", 0), "hame-2025");
       assert.strictEqual(brokerForVersion("HMD-1", 154), "hame-2024");
       assert.strictEqual(brokerForVersion("HMD-1", 155), "hame-2025");
+      // Non-target HMD ids (no V/N sub-type token) follow the base HMD route.
+      assert.strictEqual(brokerForVersion("HMD-41", 154), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMD-41", 155), "hame-2025");
     });
 
     test("VNSD/VNSA migrate at 153; VNSE3* stay always hame-2025", () => {

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -180,6 +180,11 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMF-1", 226), "hame-2025");
     });
 
+    test("HMK: hame-2024 below 226, hame-2025 at/above", () => {
+      assert.strictEqual(brokerForVersion("HMK-1", 225), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMK-1", 226), "hame-2025");
+    });
+
     test("HMJ: hame-2024 below 108, hame-2025 at/above", () => {
       assert.strictEqual(brokerForVersion("HMJ-1", 107), "hame-2024");
       assert.strictEqual(brokerForVersion("HMJ-1", 108), "hame-2025");
@@ -224,7 +229,6 @@ describe("device_matrix", () => {
 
     test("2025-only families are always hame-2025", () => {
       for (const type of [
-        "HMK-1",
         "HME-1",
         "HMD-1",
         "HMI-1",

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -52,15 +52,23 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("HME-2, HME-4, TPM-CN - require firmware >= 122.0", () => {
+    describe("HME-2, HME-4 - require firmware >= 122.0", () => {
       test("true at/above 122", () => {
         assert.strictEqual(supportsVid("HME-2", "122.0"), true);
         assert.strictEqual(supportsVid("HME-4", "125.0"), true);
-        assert.strictEqual(supportsVid("TPM-CN", "130.0"), true);
       });
       test("false below 122", () => {
         assert.strictEqual(supportsVid("HME-2", "121.9"), false);
-        assert.strictEqual(supportsVid("TPM-CN", "121.5"), false);
+      });
+    });
+
+    describe("TPM-CN - require firmware >= 101.0", () => {
+      test("true at/above 101", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "101.0"), true);
+        assert.strictEqual(supportsVid("TPM-CN", "130.0"), true);
+      });
+      test("false below 101", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "100.9"), false);
       });
     });
 
@@ -78,10 +86,10 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("HME base / other generations - always supported", () => {
-      test("HME-1 and HME-25 supported regardless of firmware", () => {
-        assert.strictEqual(supportsVid("HME-1", "1"), true);
-        assert.strictEqual(supportsVid("HME-25", "1"), true);
+    describe("HME base / other generations (non-2/3/4/5) - never supported", () => {
+      test("HME-1 and HME-25 never support vid regardless of firmware", () => {
+        assert.strictEqual(supportsVid("HME-1", "999"), false);
+        assert.strictEqual(supportsVid("HME-25", "999"), false);
       });
     });
 
@@ -240,12 +248,35 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMI-2000", 113), "hame-2025");
     });
 
+    test("HME base (non-2/3/4/5) is always hame-2024", () => {
+      assert.strictEqual(brokerForVersion("HME-1", 0), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME-1", 999), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME", 999), "hame-2024");
+    });
+
+    test("HMD-V/HMD-N always hame-2025; other HMD migrates at 155", () => {
+      assert.strictEqual(brokerForVersion("HMD-V1", 0), "hame-2025");
+      assert.strictEqual(brokerForVersion("HMD-N1", 0), "hame-2025");
+      assert.strictEqual(brokerForVersion("HMD-1", 154), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMD-1", 155), "hame-2025");
+    });
+
+    test("VNSD/VNSA migrate at 153; VNSE3* stay always hame-2025", () => {
+      assert.strictEqual(brokerForVersion("VNSD-0", 152), "hame-2024");
+      assert.strictEqual(brokerForVersion("VNSD-0", 153), "hame-2025");
+      assert.strictEqual(brokerForVersion("VNSA-0", 152), "hame-2024");
+      assert.strictEqual(brokerForVersion("VNSA2-0", 153), "hame-2025");
+      assert.strictEqual(brokerForVersion("VNSE3-0", 0), "hame-2025");
+    });
+
     test("2025-only families are always hame-2025", () => {
       for (const type of [
-        "HME-1",
-        "HMD-1",
         "VNSE3-0",
-        "VNSA-0",
+        "VNSE4-0",
+        "VDAC-0",
+        "VAAC2-0",
+        "HMD-V1",
+        "HMD-N1",
         "TPM-CN",
         "UNKNOWN-9",
       ]) {

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -227,13 +227,23 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion(" hmi-350 ", 999), "hame-2024");
     });
 
+    test("HMI (regular): hame-2024 below 129, hame-2025 at/above (#173)", () => {
+      assert.strictEqual(brokerForVersion("HMI-1", 128), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMI-1", 129), "hame-2025");
+      // HMI-3500 / HMI-5000 are not route-1 devices; they follow regular HMI.
+      assert.strictEqual(brokerForVersion("HMI-3500", 128), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMI-3500", 129), "hame-2025");
+    });
+
+    test("HMI-2000: hame-2024 below 113, hame-2025 at/above", () => {
+      assert.strictEqual(brokerForVersion("HMI-2000", 112), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMI-2000", 113), "hame-2025");
+    });
+
     test("2025-only families are always hame-2025", () => {
       for (const type of [
         "HME-1",
         "HMD-1",
-        "HMI-1",
-        "HMI-2000",
-        "HMI-3500",
         "VNSE3-0",
         "VNSA-0",
         "TPM-CN",

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -112,7 +112,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     name: "TPM-CN",
     matches: exact("TPM-CN"),
-    vidSupportVersion: 122,
+    vidSupportVersion: 101,
     inverse: "auto",
   },
 
@@ -207,18 +207,33 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     inverse: "auto",
   },
   {
-    name: "HMD",
-    matches: startsWith("HMD"),
-    vidSupportVersion: 0,
+    // HMD outdoor power stations. The "V" (V6000) and "N" (M5000) sub-types are
+    // always on the 2025 broker; any other HMD (e.g. HMD-1..7) migrates only
+    // above firmware 154. None of the HMD family supports vid (topic encryption)
+    // — the app's CommonHelper.isSupportVid has no HMD branch and returns false.
+    name: "HMD-V/HMD-N",
+    matches: (t) => t.startsWith("HMD") && (t.includes("V") || t.includes("N")),
+    vidSupportVersion: Infinity,
     inverse: "auto",
   },
   {
-    // HME base / other HME generations (e.g. HME-0, HME-1, HME-6, HME-25): no
-    // firmware gate on topic encryption. The exact HME-2/3/4/5 entries above
+    name: "HMD",
+    matches: startsWith("HMD"),
+    brokerRoutes: migrate2024to2025(155),
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // HME base / other HME generations not in {HME-2,3,4,5} (e.g. bare "HME",
+    // HME-1, HME-6). The app's CtVersionController only enumerates HME-2/3/4/5
+    // (plus TPM/SMR); any other HME falls through to a hard `return false` in
+    // both isSupportMqttEncrypt and isSupportVid, so these stay on the 2024
+    // broker and never use topic encryption. The exact HME-2/3/4/5 entries above
     // take precedence.
     name: "HME",
     matches: startsWith("HME"),
-    vidSupportVersion: 0,
+    brokerRoutes: ALWAYS_2024,
+    vidSupportVersion: Infinity,
     inverse: "auto",
     astraMeter: true,
   },
@@ -235,7 +250,19 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     inverse: "auto",
   },
   {
-    // VNSE3 / VNSA / VNSD all share the same behavior.
+    // Venus VNSD* / VNSA* (incl. VNSD2, VNSA2) migrate from the 2024 broker to
+    // the 2025 broker at firmware 153. Must precede the general VNS entry. The
+    // other Venus strategies (VNSE3*, VNSE4) short-circuit to the 2025 broker
+    // unconditionally and are handled by the catch-all below; VAAC2/VDAC do not
+    // start with "VNS" and fall through to the default (also always-2025).
+    name: "VNSD/VNSA",
+    matches: (t) => t.startsWith("VNSD") || t.startsWith("VNSA"),
+    brokerRoutes: migrate2024to2025(153),
+    vidSupportVersion: 123,
+    inverse: "auto",
+  },
+  {
+    // VNSE3* / VNSE4: always on the 2025 broker.
     name: "VNS",
     matches: startsWith("VNS"),
     vidSupportVersion: 123,

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -164,6 +164,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     name: "HMK",
     matches: startsWith("HMK"),
+    brokerRoutes: migrate2024to2025(226),
     vidSupportVersion: 230,
     useRemoteTopicIdVersions: [226],
     inverse: "selectable",

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -211,8 +211,10 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     // always on the 2025 broker; any other HMD (e.g. HMD-1..7) migrates only
     // above firmware 154. None of the HMD family supports vid (topic encryption)
     // — the app's CommonHelper.isSupportVid has no HMD branch and returns false.
+    // Match the V/N sub-type token directly (HMD-V*/HMD-N*) rather than a loose
+    // substring, so other HMD ids that merely contain V/N elsewhere don't match.
     name: "HMD-V/HMD-N",
-    matches: (t) => t.startsWith("HMD") && (t.includes("V") || t.includes("N")),
+    matches: (t) => t.startsWith("HMD-V") || t.startsWith("HMD-N"),
     vidSupportVersion: Infinity,
     inverse: "auto",
   },

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -132,6 +132,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     // HMI models. Whole-token match so "HMI-12000" / "HMI-20001" don't match.
     name: "HMI-2000",
     matches: (t) => t.startsWith("HMI") && /\b2000\b/.test(t),
+    brokerRoutes: migrate2024to2025(113),
     vidSupportVersion: 105,
     inverse: "auto",
   },
@@ -222,8 +223,14 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     astraMeter: true,
   },
   {
+    // Regular HMI inverters migrate from the 2024 broker to the 2025 broker at
+    // firmware 129. The HMI-350/HMI-500 (always 2024) and HMI-2000 (migrates at
+    // 113) exact entries above take precedence. Without an explicit brokerRoutes
+    // this would silently default to always-2025 and strand pre-129 devices on
+    // the wrong broker (#173).
     name: "HMI",
     matches: startsWith("HMI"),
+    brokerRoutes: migrate2024to2025(129),
     vidSupportVersion: 120,
     inverse: "auto",
   },


### PR DESCRIPTION
## Summary
1.4.1 routed several device families to the wrong MQTT broker (and/or used the wrong topic-encryption threshold) because their device-matrix entries had no explicit broker routing and silently defaulted to the 2025 broker. This PR restores firmware-based routing for the affected families and corrects a few VID (topic-encryption) thresholds.

## Fixes
- **HMI (regular)** — regression in 1.4.1: all HMI inverters were placed on the 2025 broker regardless of firmware, leaving pre-129 devices (e.g. Marstek Saturn M800 / HMI-1) unable to communicate. They now migrate from the 2024 broker to the 2025 broker at firmware ≥129, and HMI-350/HMI-500 stay on the 2024 broker. Fixes #173.
- **HMI-2000** — migrates at firmware ≥113 (was always-2025).
- **HMK** — migrates at firmware ≥226, matching HMA/HMF (was always-2025).
- **TPM-CN** — uses topic encryption (VID) from firmware ≥101 (was 122).
- **HME (base / non-2/3/4/5, e.g. HME-1)** — stays on the 2024 broker and never uses topic encryption (was always-2025 with always-on VID).
- **Venus VNSD/VNSA** (incl. VNSD2/VNSA2) — migrate at firmware ≥153; VNSE3*/VNSE4 remain always-2025.
- **HMD** — HMD-V / HMD-N (V6000 / M5000) stay always-2025; other HMD migrate at firmware >154; no HMD sub-type uses topic encryption.

HMB was reviewed and left unchanged (correctly always on the 2024 broker).

## Tests & docs
- Added `brokerForVersion` / `supportsVid` tests for each affected family and version boundary.
- Updated `docs/device-matrix.md` (matrix rows + matching-precedence rules) and added a `CHANGELOG.md` entry.

> Note: these thresholds are not yet confirmed against live devices.

https://claude.ai/code/session_0142mTMkKPDqdwJu9ddShmoT