### PR TITLE
Fix remote_id salt selection for "0"-flag salt pairs (#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Fixed `remote_id` derivation for devices whose API `salt` begins with a "0" flag (e.g. some HMI-2000 / MI2000W on fw V115): the relay now selects the correct salt component for `CommonHelper.cq` to match the official app's behavior. Previously it always used the first component, producing a remote topic id the cloud never assigned, so polls were forwarded local→remote but device responses never came back (#182). Note: not yet confirmed against a live device
 
 
 ## [1.4.2] - 2026-06-01

--- a/src/main.ts
+++ b/src/main.ts
@@ -316,10 +316,10 @@ async function start() {
           logger.debug(
             `Device ${device.device_id} supports CommonHelper.cq method, using salt-based calculation`,
           );
-          const firstSalt = CommonHelper.extractFirstSalt(device.salt);
-          if (firstSalt) {
+          const selectedSalt = CommonHelper.selectSalt(device.salt);
+          if (selectedSalt) {
             device.remote_id = CommonHelper.cq(
-              firstSalt,
+              selectedSalt,
               device.mac,
               device.type,
             );

--- a/src/topic.test.ts
+++ b/src/topic.test.ts
@@ -122,40 +122,59 @@ describe("CommonHelper", () => {
     });
   });
 
-  describe("extractFirstSalt method", () => {
-    test("should extract first salt from comma-separated pair", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt("salt1,salt2"), "salt1");
+  describe("selectSalt method", () => {
+    test("should use the first salt when it is real salt material", () => {
+      assert.strictEqual(CommonHelper.selectSalt("salt1,salt2"), "salt1");
       assert.strictEqual(
-        CommonHelper.extractFirstSalt("first,second,third"),
+        CommonHelper.selectSalt("first,second,third"),
         "first",
       );
     });
 
+    test("should use the second salt when the first starts with a '0' flag", () => {
+      // Matches the official app's behavior: a leading "0" component is a
+      // control flag, so cq must be fed the second component (issue #182).
+      assert.strictEqual(CommonHelper.selectSalt("0,realsalt"), "realsalt");
+      assert.strictEqual(CommonHelper.selectSalt("0abc,realsalt"), "realsalt");
+      assert.strictEqual(CommonHelper.selectSalt(" 0 , realsalt "), "realsalt");
+    });
+
+    test("should not treat a non-leading '0' as a flag", () => {
+      assert.strictEqual(CommonHelper.selectSalt("a0,salt2"), "a0");
+    });
+
     test("should handle single salt value", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt("onlysalt"), "onlysalt");
+      assert.strictEqual(CommonHelper.selectSalt("onlysalt"), "onlysalt");
+      // A lone "0..." component has no second value to fall back to.
+      assert.strictEqual(CommonHelper.selectSalt("0only"), "0only");
     });
 
     test("should handle salt with whitespace", () => {
+      assert.strictEqual(CommonHelper.selectSalt(" salt1 , salt2 "), "salt1");
       assert.strictEqual(
-        CommonHelper.extractFirstSalt(" salt1 , salt2 "),
-        "salt1",
-      );
-      assert.strictEqual(
-        CommonHelper.extractFirstSalt("  trimmed  ,  other  "),
+        CommonHelper.selectSalt("  trimmed  ,  other  "),
         "trimmed",
       );
     });
 
     test("should return empty string for invalid input", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt(""), "");
-      assert.strictEqual(CommonHelper.extractFirstSalt(null as any), "");
-      assert.strictEqual(CommonHelper.extractFirstSalt(undefined as any), "");
+      assert.strictEqual(CommonHelper.selectSalt(""), "");
+      assert.strictEqual(CommonHelper.selectSalt(null as any), "");
+      assert.strictEqual(CommonHelper.selectSalt(undefined as any), "");
     });
 
     test("should handle edge cases", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt(",second"), "");
-      assert.strictEqual(CommonHelper.extractFirstSalt("first,"), "first");
-      assert.strictEqual(CommonHelper.extractFirstSalt(","), "");
+      assert.strictEqual(CommonHelper.selectSalt(",second"), "");
+      assert.strictEqual(CommonHelper.selectSalt("first,"), "first");
+      assert.strictEqual(CommonHelper.selectSalt(","), "");
+    });
+
+    test("extractFirstSalt remains as a backward-compatible alias", () => {
+      assert.strictEqual(CommonHelper.extractFirstSalt("salt1,salt2"), "salt1");
+      assert.strictEqual(
+        CommonHelper.extractFirstSalt("0,realsalt"),
+        "realsalt",
+      );
     });
   });
 });

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -314,17 +314,40 @@ class CommonHelper {
   }
 
   /**
-   * Extracts the first salt value from a comma-separated salt pair
+   * Selects the salt component that must be fed into {@link cq} to derive a
+   * device's remote topic id, from the comma-separated salt pair the Hame API
+   * returns in its device list (`salt: "<a>,<b>"`).
+   *
+   * This matches the official Marstek app's behavior: the first component is
+   * not always salt material. When it starts with "0" it is a control flag,
+   * and the **second** component is the salt used to derive the topic id.
+   * Only when the first component is real salt (does not start with "0") is
+   * it used directly. Always taking `parts[0]` therefore produces a wrong
+   * remote id for devices whose salt begins with a "0" flag, so their cloud
+   * responses never come back (see issue #182).
+   *
    * @param saltPair The comma-separated salt pair (e.g., "salt1,salt2")
-   * @returns The first salt value, or empty string if invalid
+   * @returns The salt value to use with `cq`, or empty string if invalid
    */
-  static extractFirstSalt(saltPair: string): string {
+  static selectSalt(saltPair: string): string {
     if (!saltPair || typeof saltPair !== "string") {
       return "";
     }
 
-    const parts = saltPair.split(",");
-    return parts.length > 0 ? parts[0].trim() : "";
+    const parts = saltPair.split(",").map((part) => part.trim());
+    // First component is a control flag ("0..."): use the second salt value.
+    if (parts.length > 1 && parts[0].startsWith("0")) {
+      return parts[1];
+    }
+    return parts[0];
+  }
+
+  /**
+   * @deprecated Use {@link selectSalt}, which also handles the "0"-flag salt
+   * pairs. Retained as an alias so existing references keep compiling.
+   */
+  static extractFirstSalt(saltPair: string): string {
+    return CommonHelper.selectSalt(saltPair);
   }
 }
 


### PR DESCRIPTION
## Summary

Fixes the salt component the relay feeds into `CommonHelper.cq` when deriving a device's remote topic id. This is a candidate fix for #182 (HMI-2000 / MI2000W on fw V115: polls forwarded local→remote but no response ever returns).

The Hame API returns each device's `salt` as a **two-part value** (`"<a>,<b>"`). The relay always used the **first** component (`extractFirstSalt`). But the official app treats a leading `"0"` component as a **control flag** and uses the **second** component as the real salt. So for any device whose salt begins with a `"0"` flag, the relay derives a remote topic id the cloud never assigned — it subscribes to / publishes on the wrong `…/device/<id>/ctrl` and `…/App/<id>/ctrl` topics, which is exactly the one-way symptom in #182: polls go out, nothing ever comes back.

## Change

- Add `CommonHelper.selectSalt(saltPair)` in `src/topic.ts`, matching the official app's selection: `parts[0]` when it is real salt material, `parts[1]` when `parts[0]` starts with `"0"`.
- Use it in `src/main.ts` for the `cq` remote-id path.
- Keep `extractFirstSalt` as a thin, deprecated alias so nothing else breaks.
- Tests + CHANGELOG entry.

This only changes behavior for salt pairs whose first component starts with `"0"` (the broken case). Salts where the first component is real material are unchanged, so devices that work today are unaffected.

## Caveats

- **Not yet confirmed against a live device.** The reporter's actual `salt` value is needed to confirm this is their specific failure — i.e. that their device's salt begins with a `"0"` flag.
- Only the common "use the second salt component" case is handled. There are additional control-flag cases (where the id is requested from the device rather than computed locally) that can't be reproduced from the salt alone; those are left as follow-up.

Closing #182 should wait until confirmed against the reporter's device.

https://claude.ai/code/session_01WjV6foVpywa9WucDnkUcjy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote device identification for certain device configurations where responses were not returning correctly during poll forwarding. The relay now properly derives device identifiers to match the official app's behavior.

* **Tests**
  * Expanded test coverage for device configuration edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->