### PR TITLE
Venus series devices always use hame-2025 broker

### DIFF
--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -48,7 +48,7 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | |
 | HMI-2000            | hame-2024 → hame-2025 @113  | 105   | —               | auto        | 4-PV microinverter |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", see #158 / #164 |
-| VNSD, VNSA (incl. VNSD2, VNSA2) | hame-2024 → hame-2025 @153 | 123 | —          | auto        | Venus series |
+| VNSD, VNSA (incl. VNSD2, VNSA2) | hame-2025      | 123   | —               | auto        | Venus series; always 2025 |
 | VNSE3, VNSE4        | hame-2025                   | 123   | —               | auto        | Venus series |
 | _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device |
 
@@ -62,7 +62,6 @@ A device type is matched most-specific first:
      like `HMI-3500`, `HMI-5000`, `HMI-12000` or `HMI-20001` fall through to the
      regular HMI profile.
    - `HMD-V*`/`HMD-N*` (V6000 / M5000 sub-types) before base `HMD`.
-   - `VNSD`/`VNSA` (incl. `VNSD2`/`VNSA2`) before base `VNS`.
 3. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
    `JPLS`, `HMD`, `HME`, `HMI`, `VNS`.
 4. Unknown — assume a `hame-2025`, topic-encryption-capable device.

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -264,16 +264,29 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMD-41", 155), "hame-2025");
     });
 
-    test("VNSD/VNSA migrate at 153; VNSE3* stay always hame-2025", () => {
-      assert.strictEqual(brokerForVersion("VNSD-0", 152), "hame-2024");
-      assert.strictEqual(brokerForVersion("VNSD-0", 153), "hame-2025");
-      assert.strictEqual(brokerForVersion("VNSA-0", 152), "hame-2024");
-      assert.strictEqual(brokerForVersion("VNSA2-0", 153), "hame-2025");
-      assert.strictEqual(brokerForVersion("VNSE3-0", 0), "hame-2025");
+    test("all Venus VNS* types are always hame-2025 (no 2024 migration)", () => {
+      // The whole Venus family runs on the 2025 broker at any firmware, including
+      // VNSD-0 on firmware 142.
+      for (const type of [
+        "VNSD-0",
+        "VNSA-0",
+        "VNSD2-0",
+        "VNSA2-0",
+        "VNSE3-0",
+        "VNSE4-0",
+      ]) {
+        assert.strictEqual(brokerForVersion(type, 0), "hame-2025", type);
+        assert.strictEqual(brokerForVersion(type, 142), "hame-2025", type);
+        assert.strictEqual(brokerForVersion(type, 999), "hame-2025", type);
+      }
     });
 
     test("2025-only families are always hame-2025", () => {
       for (const type of [
+        "VNSD-0",
+        "VNSA-0",
+        "VNSD2-0",
+        "VNSA2-0",
         "VNSE3-0",
         "VNSE4-0",
         "VDAC-0",

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -252,19 +252,10 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     inverse: "auto",
   },
   {
-    // Venus VNSD* / VNSA* (incl. VNSD2, VNSA2) migrate from the 2024 broker to
-    // the 2025 broker at firmware 153. Must precede the general VNS entry. The
-    // other Venus strategies (VNSE3*, VNSE4) short-circuit to the 2025 broker
-    // unconditionally and are handled by the catch-all below; VAAC2/VDAC do not
-    // start with "VNS" and fall through to the default (also always-2025).
-    name: "VNSD/VNSA",
-    matches: (t) => t.startsWith("VNSD") || t.startsWith("VNSA"),
-    brokerRoutes: migrate2024to2025(153),
-    vidSupportVersion: 123,
-    inverse: "auto",
-  },
-  {
-    // VNSE3* / VNSE4: always on the 2025 broker.
+    // Venus series (VNSD*/VNSA* incl. VNSD2/VNSA2, VNSE3*, VNSE4): always on the
+    // 2025 broker, at any firmware — the whole family runs on the 2025
+    // infrastructure and never used the 2024 broker. VAAC2/VDAC do not start with
+    // "VNS" and reach the default (also always-2025).
     name: "VNS",
     matches: startsWith("VNS"),
     vidSupportVersion: 123,


### PR DESCRIPTION
## Summary
Simplifies device routing configuration by removing the firmware-based migration logic for Venus series devices (VNSD, VNSA, VNSD2, VNSA2, VNSE3, VNSE4). These devices now unconditionally route to the hame-2025 broker at any firmware version, eliminating the previous migration point at firmware 153.

## Key Changes
- **Removed VNSD/VNSA migration profile**: Deleted the separate device profile that migrated VNSD/VNSA devices from hame-2024 to hame-2025 at firmware 153
- **Consolidated Venus routing**: Merged all Venus series devices (VNSD*, VNSA*, VNSE3*, VNSE4*) under a single "VNS" profile that always routes to hame-2025
- **Updated documentation**: Clarified in device-matrix.md that the entire Venus family always uses hame-2025, removing the migration version notation
- **Simplified matching logic**: Removed the need for most-specific-first matching of VNSD/VNSA before the base VNS entry

## Implementation Details
- The VNS profile now handles all Venus device types with a simple `startsWith("VNS")` matcher
- All Venus devices maintain vidSupportVersion of 123 and auto inverse configuration
- Test coverage updated to verify all Venus types (VNSD-0, VNSA-0, VNSD2-0, VNSA2-0, VNSE3-0, VNSE4-0) consistently route to hame-2025 across firmware versions 0, 142, and 999

https://claude.ai/code/session_01Fv9ef565jFW8Nuhhb5YMCv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Simplified device broker routing for Venus series devices (VNSD, VNSA, VNSD2, VNSA2, VNSE3, VNSE4) to consistently use the 2025 broker across all firmware versions.
  * Updated device support matrix and corresponding tests to reflect consistent routing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->