### PR TITLE
Fix Venus series devices broker selection for all firmware versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [1.4.3] - 2026-06-13
+- Fixed Venus series devices (e.g. VNSD/VNSA, including VNSD2/VNSA2) using the wrong broker: the whole Venus family now always uses the hame-2025 broker at any firmware instead of migrating from the 2024 broker at firmware 153. This restores connectivity for devices such as a VNSD-0 on firmware 142 that only work against hame-2025 (#187)
 
 
 ## [1.4.2] - 2026-06-01


### PR DESCRIPTION
## Summary
Fixed an issue where Venus series devices (VNSD/VNSA, including VNSD2/VNSA2) were using incorrect broker selection logic based on firmware version, causing connectivity failures on certain firmware versions.

## Changes
- Updated broker selection for the entire Venus device family to always use the hame-2025 broker regardless of firmware version
- Previously, devices would migrate from the 2024 broker to hame-2025 only at firmware 153, breaking connectivity for devices on earlier firmware versions (e.g., VNSD-0 on firmware 142)
- This change ensures consistent broker usage across all Venus family devices and firmware versions

## Details
This fix restores connectivity for Venus series devices that only work against the hame-2025 broker, resolving the regression reported in #187.

https://claude.ai/code/session_01T6Pp3XYm1nUpWno8EXLE2e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connectivity issues for Venus series devices (VNSD/VNSA, VNSD2/VNSA2) by correcting network configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->