### PR TITLE
Add Marstek ecosystem project overview to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,19 @@ This project helps you integrate your Marstek storage systems with both the offi
 
 **Important Note**: Hame Relay only forwards MQTT messages between the Hame cloud and your local MQTT broker. It does not create Home Assistant device entities or provide device integration. For full Home Assistant integration with automatic device discovery and control entities, use [hm2mqtt](https://github.com/tomquist/hm2mqtt) on top of Hame Relay.
 
+<!-- marstek-family:start -->
+**🔋 The Marstek ecosystem.** This repo is part of a family of open-source tools for Marstek batteries (B2500, Venus, Jupiter, …):
+
+| Project | What it does |
+|---|---|
+| [hm2mqtt](https://github.com/tomquist/hm2mqtt) | Brings your battery into your smart home, turning its raw data into readable sensors and controls (e.g. in Home Assistant) |
+| **hame-relay** (this repo) | Connects the official Marstek cloud/app and your local smart home so both work together, forwarding data whichever way your battery is set up |
+| [marsrelay](https://github.com/tomquist/marsrelay) | Runs your battery completely offline, with no internet or Marstek cloud, while still sending all its data to your smart home |
+| [AstraMeter](https://github.com/tomquist/astrameter) | Tells your battery your live grid usage (read from your existing meter) so it charges and discharges to avoid buying or selling power |
+| [hmjs](https://github.com/tomquist/hmjs) | Sets up and configures B2500 batteries over Bluetooth, right from your web browser, with no app or account needed |
+| [esphome-b2500](https://github.com/tomquist/esphome-b2500) | Continuously monitors and controls a B2500 over Bluetooth using a small ESP32 board |
+<!-- marstek-family:end -->
+
 ## Quick Start for Home Assistant Users
 
 The easiest way to get started is with the Home Assistant app (part of Home Assistant **Apps (formerly known as add-ons)**):


### PR DESCRIPTION
## Summary
Added a comprehensive overview section to the README documenting the Marstek ecosystem of open-source tools and how hame-relay fits within it.

## Changes
- Added a new "Marstek ecosystem" section with a table listing related projects:
  - **hm2mqtt**: Home Assistant integration with automatic device discovery
  - **hame-relay** (this repo): Cloud and local MQTT bridge
  - **marsrelay**: Offline-only battery operation
  - **AstraMeter**: Grid usage awareness for smart charging/discharging
  - **hmjs**: Browser-based B2500 setup and configuration
  - **esphome-b2500**: ESP32-based Bluetooth monitoring and control
- Included HTML comments (`<!-- marstek-family:start/end -->`) to mark the section for potential automation or updates
- Positioned the section prominently after the important note about Home Assistant integration

## Details
This addition helps users understand the broader ecosystem of Marstek tools available and how hame-relay complements other projects for different use cases (cloud integration, offline operation, smart home integration, etc.).

https://claude.ai/code/session_014X7oipnV3LXbrsLYoii4yq