### PR TITLE
Add support for Marstek CT002 new generation (TPM2-0)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+# Agent guidelines
+
+## Changelog
+
+Entries in `CHANGELOG.md` are for end users. Describe **what changed from the
+user's perspective**, not how it was implemented. Do not include implementation
+details such as broker names, firmware thresholds, internal function or module
+names, matching rules, or code-level specifics — those belong in
+`docs/device-matrix.md`, code comments, and the commit message.
+
+Keep entries short. Reference the relevant issue/PR number in parentheses.
+
+Good: `Add support for the Marstek CT002 new generation (device type TPM2-0) (#201)`
+
+Avoid: `Add a TPM2 device profile using the 2025 broker with salt-based topic-id
+encryption (vidSupportVersion 0) …`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,15 +2,6 @@
 
 ## Changelog
 
-Entries in `CHANGELOG.md` are for end users. Describe **what changed from the
-user's perspective**, not how it was implemented. Do not include implementation
-details such as broker names, firmware thresholds, internal function or module
-names, matching rules, or code-level specifics — those belong in
-`docs/device-matrix.md`, code comments, and the commit message.
-
-Keep entries short. Reference the relevant issue/PR number in parentheses.
-
-Good: `Add support for the Marstek CT002 new generation (device type TPM2-0) (#201)`
-
-Avoid: `Add a TPM2 device profile using the 2025 broker with salt-based topic-id
-encryption (vidSupportVersion 0) …`
+`CHANGELOG.md` entries are for end users: describe what changed, not how it was
+implemented. No implementation details (broker names, firmware thresholds,
+internal names). Keep it short and reference the issue/PR number.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [Next]
-- Add support for the Marstek CT002 new generation (device type `TPM2-0`): it uses the 2025 broker with salt-based topic-id encryption on every firmware and always uses inverse forwarding. The type is now recognized so it no longer logs an "Unknown device type" warning (#201)
+- Add support for the Marstek CT002 new generation (device type `TPM2-0`) (#201)
 
 
 ## [1.4.3] - 2026-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Add support for the Marstek CT002 new generation (device type `TPM2-0`): it uses the 2025 broker with salt-based topic-id encryption on every firmware and always uses inverse forwarding. The type is now recognized so it no longer logs an "Unknown device type" warning (#201)
 
 
 ## [1.4.3] - 2026-06-13

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Marstek storage systems can be configured to use either:
 This tool bridges these two scenarios by forwarding MQTT messages between your local broker and the Hame broker. The app automatically determines the best forwarding direction for each device type:
 
 ### Automatic Configuration
-- **JPLS, HMM, HMN, HME, TPM-CN, HMG and other devices**: Always use inverse forwarding (required for proper operation)
+- **JPLS, HMM, HMN, HME, TPM-CN, TPM2 (CT002), HMG and other devices**: Always use inverse forwarding (required for proper operation)
 - **HMA, HMF, HMK, HMJ, HMB devices**: Use selective forwarding based on your configuration (see `inverse_forwarding_device_ids`)
 
 See the full [device support matrix](docs/device-matrix.md) for per-device broker selection and topic-encryption behavior across firmware versions.

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -45,6 +45,7 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HME-2, HME-4        | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family |
 | HME-3, HME-5        | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
 | TPM-CN              | hame-2025                   | 101   | —               | auto        | standalone identifier |
+| TPM2                | hame-2025                   | 0     | —               | auto        | CT002 new generation (`TPM2-0`, #201) |
 | HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | |
 | HMI-2000            | hame-2024 → hame-2025 @113  | 105   | —               | auto        | 4-PV microinverter |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", see #158 / #164 |
@@ -63,7 +64,7 @@ A device type is matched most-specific first:
      regular HMI profile.
    - `HMD-V*`/`HMD-N*` (V6000 / M5000 sub-types) before base `HMD`.
 3. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
-   `JPLS`, `HMD`, `HME`, `HMI`, `VNS`.
+   `JPLS`, `HMD`, `HME`, `HMI`, `TPM2`, `VNS`.
 4. Unknown — assume a `hame-2025`, topic-encryption-capable device.
 
 ## AstraMeter placeholder devices

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -74,6 +74,7 @@ describe("device_matrix", () => {
 
     describe("TPM2 (CT002 new generation) - always topic-encryption capable", () => {
       test("true at any firmware (threshold 0)", () => {
+        assert.strictEqual(supportsVid("TPM2-0", "0"), true);
         assert.strictEqual(supportsVid("TPM2-0", "105.0"), true);
         assert.strictEqual(supportsVid("TPM2-0", "1.0"), true);
       });

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -72,6 +72,16 @@ describe("device_matrix", () => {
       });
     });
 
+    describe("TPM2 (CT002 new generation) - always topic-encryption capable", () => {
+      test("true at any firmware (threshold 0)", () => {
+        assert.strictEqual(supportsVid("TPM2-0", "105.0"), true);
+        assert.strictEqual(supportsVid("TPM2-0", "1.0"), true);
+      });
+      test("case insensitive", () => {
+        assert.strictEqual(supportsVid("tpm2-0", "105.0"), true);
+      });
+    });
+
     describe("HME-3, HME-5 - require firmware >= 120.0", () => {
       test("true at/above 120", () => {
         assert.strictEqual(supportsVid("HME-3", "120.0"), true);
@@ -294,6 +304,7 @@ describe("device_matrix", () => {
         "HMD-V1",
         "HMD-N1",
         "TPM-CN",
+        "TPM2-0",
         "UNKNOWN-9",
       ]) {
         assert.strictEqual(brokerForVersion(type, 0), "hame-2025", type);
@@ -340,6 +351,7 @@ describe("device_matrix", () => {
         "HMI-1",
         "HMI-350",
         "TPM-CN",
+        "TPM2-0",
         "VNSE3-0",
         "UNKNOWN",
       ]) {
@@ -382,6 +394,11 @@ describe("device_matrix", () => {
       assert.strictEqual(resolveProfile("HME-3").name, "HME-3/HME-5");
       assert.strictEqual(resolveProfile("HME-25").name, "HME");
       assert.strictEqual(resolveProfile("HME-1").name, "HME");
+    });
+
+    test("TPM2 resolves to its own profile without colliding with TPM-CN", () => {
+      assert.strictEqual(resolveProfile("TPM2-0").name, "TPM2");
+      assert.strictEqual(resolveProfile("TPM-CN").name, "TPM-CN");
     });
 
     test("unknown types resolve to the default profile", () => {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -115,6 +115,16 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     vidSupportVersion: 101,
     inverse: "auto",
   },
+  {
+    // Marstek CT002 "new generation" (reported as TPM2-0, #201). Ships on the
+    // 2025 broker and uses salt-based topic-id encryption on every firmware, so
+    // there is no pre-encryption threshold. Whole-family match (TPM2-*) so future
+    // generations are covered; TPM-CN starts with "TPM-" and is unaffected.
+    name: "TPM2",
+    matches: startsWith("TPM2"),
+    vidSupportVersion: 0,
+    inverse: "auto",
+  },
 
   // --- HMI model-token rules (must precede the HMI base entry) ---
   {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export const deviceTypes = [
   "HMI",
   "HMM",
   "HMN",
+  "TPM2",
   "VNSE3",
   "VNSA",
   "VNSD",


### PR DESCRIPTION
## Summary
Add device profile support for the Marstek CT002 new generation, reported as device type `TPM2-0`. This device always supports topic-encryption regardless of firmware version and uses the hame-2025 broker.

## Changes
- **Device Profile**: Added `TPM2` profile with `startsWith("TPM2")` matching to cover future TPM2 generations while avoiding collision with existing `TPM-CN` devices
- **VID Support**: Set `vidSupportVersion: 0` to indicate topic-encryption capability on all firmware versions (no threshold)
- **Type Registration**: Added `TPM2` to the `deviceTypes` constant for type safety
- **Test Coverage**: 
  - Added tests for TPM2 topic-encryption support at any firmware version
  - Added case-insensitivity test
  - Added profile resolution test to ensure TPM2 and TPM-CN don't collide
  - Updated broker version tests to include TPM2-0
- **Documentation**: Updated device-matrix.md and README.md to include TPM2 in device lists and matching order
- **Changelog**: Added user-facing entry referencing issue #201

## Implementation Details
- The `TPM2` profile uses prefix matching (`startsWith("TPM2")`) rather than exact matching to future-proof for potential TPM2-1, TPM2-2, etc. variants
- `vidSupportVersion: 0` means the device supports VID (topic-encryption) from firmware version 0 onwards (always)
- Profile ordering ensures TPM2 is checked before the generic unknown device fallback

https://claude.ai/code/session_019ruZVj93VjrNSE9qWZNfjC

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the next-generation Marstek CT002 (`TPM2`) device type.
  * Enabled automatic forwarding configuration and topic encryption support for compatible devices.
  * Added device identification and broker support for `TPM2` models.

* **Documentation**
  * Updated setup guidance and the supported device matrix for `TPM2`.
  * Added an unreleased changelog entry referencing issue/PR `#201`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->