### PR TITLE
Support Jupiter 2xx firmware line with separate broker/encryption routes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [Next]
 - Add support for the Marstek CT002 new generation (device type `TPM2-0`) (#201)
+- Fixed Marstek Jupiter devices (JPLS, HMM, HMN) on firmware 2xx never receiving device data: messages were forwarded to the app but nothing came back, so no entities were created. Jupiter ships two separate firmware lines and the 2xx line needs different handling than the 1xx line (#209)
 
 
 ## [1.4.3] - 2026-06-13

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -36,9 +36,12 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMK                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
 | HMJ                 | hame-2024 → hame-2025 @108  | 116   | [108]           | selectable  | |
 | HMG                 | hame-2024 → hame-2025 @153  | 154   | —               | auto        | |
-| HMM                 | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
-| HMN                 | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
-| JPLS (`JPLS-NH`)    | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
+| HMM (1xx firmware)  | hame-2024 → hame-2025 @135  | 136   | —               | auto        | see "Jupiter firmware lines" |
+| HMM (2xx firmware)  | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
+| HMN (1xx firmware)  | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
+| HMN (2xx firmware)  | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
+| JPLS (1xx firmware) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | `JPLS-NH` |
+| JPLS (2xx firmware) | hame-2024 → hame-2025 @232  | 236   | —               | auto        | e.g. Jupiter C Plus, #209 |
 | HMD-V, HMD-N        | hame-2025                   | never | —               | auto        | V6000 / M5000 outdoor power |
 | HMD (other)         | hame-2024 → hame-2025 @155  | never | —               | auto        | outdoor power station |
 | HME (base / other)  | hame-2024                   | never | —               | auto        | AstraMeter family; non-2/3/4/5 |
@@ -52,6 +55,15 @@ switches to encrypted topic ids, and how forwarding is configured.
 | VNSD, VNSA (incl. VNSD2, VNSA2) | hame-2025      | 123   | —               | auto        | Venus series; always 2025 |
 | VNSE3, VNSE4        | hame-2025                   | 123   | —               | auto        | Venus series |
 | _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device |
+
+## Jupiter firmware lines
+
+The Jupiter family (HMM, HMN, JPLS) ships two independent firmware lines, a
+1xx line and a 2xx line (Jupiter C Plus / `JPLS-8H` is on the 2xx line). A 2xx
+firmware is not simply "newer" than a 1xx one: the line starts over on the 2024
+broker with plaintext topic ids and migrates again at its own thresholds. So a
+JPLS on fw 231 is on the 2024 broker without topic encryption, while the same
+family on fw 136 is already on the 2025 broker with encrypted topic ids.
 
 ## Matching precedence
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -29,6 +29,26 @@ describe("device_matrix", () => {
       });
     });
 
+    describe("Jupiter 2xx firmware line - requires firmware >= 236 (#209)", () => {
+      test("false across the whole 2xx range below 236", () => {
+        assert.strictEqual(supportsVid("JPLS-8H", "200"), false);
+        assert.strictEqual(supportsVid("JPLS-8H", "231"), false);
+        assert.strictEqual(supportsVid("JPLS-8H", "235.9"), false);
+        assert.strictEqual(supportsVid("HMM-1", "231"), false);
+        assert.strictEqual(supportsVid("HMN-1", "231"), false);
+      });
+
+      test("true at/above 236", () => {
+        assert.strictEqual(supportsVid("JPLS-8H", "236"), true);
+        assert.strictEqual(supportsVid("HMM-1", "240"), true);
+      });
+
+      test("1xx line is unaffected", () => {
+        assert.strictEqual(supportsVid("JPLS-8H", "136"), true);
+        assert.strictEqual(supportsVid("JPLS-8H", "199"), true);
+      });
+    });
+
     describe("HMB/HMA/HMK/HMF devices - require firmware >= 230.0", () => {
       test("true at/above 230", () => {
         assert.strictEqual(supportsVid("HMB", "230.0"), true);
@@ -220,6 +240,19 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMN-1", 134), "hame-2024");
       assert.strictEqual(brokerForVersion("JPLS-8H", 134), "hame-2024");
       assert.strictEqual(brokerForVersion("JPLS-8H", 135), "hame-2025");
+    });
+
+    test("Jupiter 2xx firmware line restarts on hame-2024 (#209)", () => {
+      // JPLS migrates at 232, HMM/HMN at 230.
+      assert.strictEqual(brokerForVersion("JPLS-8H", 200), "hame-2024");
+      assert.strictEqual(brokerForVersion("JPLS-8H", 231), "hame-2024");
+      assert.strictEqual(brokerForVersion("JPLS-8H", 232), "hame-2025");
+      assert.strictEqual(brokerForVersion("HMM-1", 229), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMM-1", 230), "hame-2025");
+      assert.strictEqual(brokerForVersion("HMN-1", 229), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMN-1", 230), "hame-2025");
+      // The 1xx line keeps its own thresholds.
+      assert.strictEqual(brokerForVersion("JPLS-8H", 199), "hame-2025");
     });
 
     test("HME-2/HME-4: hame-2024 below 119, hame-2025 at/above (#145)", () => {

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -12,13 +12,6 @@ import {
 
 describe("device_matrix", () => {
   describe("supportsVid (salt-based topic encryption threshold)", () => {
-    // Jupiter firmware is integer-valued, and only integers are asserted here:
-    // the app decides which firmware line a device is on from the *shape* of
-    // the version string (three digits starting with "1"), which the numeric
-    // steps below can only reproduce for whole numbers. A fractional version
-    // such as "150.5" would fall out of the app's 1xx line but still sits
-    // inside the 136–199 step, so asserting it would encode our model rather
-    // than the device's behavior.
     describe("Jupiter devices (JPLS, HMM, HMN) - require firmware >= 136", () => {
       test("true for JPLS at 136, HMM at 140, HMN at 150", () => {
         assert.strictEqual(supportsVid("JPLS", "136"), true);
@@ -33,6 +26,21 @@ describe("device_matrix", () => {
       test("case insensitive", () => {
         assert.strictEqual(supportsVid("jpls", "136"), true);
         assert.strictEqual(supportsVid("hmm", "136"), true);
+      });
+
+      // The app puts a device on the 1xx line only when the raw firmware
+      // string is exactly three digits starting with "1", so a value that is
+      // numerically inside 136–199 but shaped differently belongs to the 2xx
+      // line, where nothing below 236 is encrypted.
+      test("versions not shaped like 1xx stay off the encrypted 1xx line", () => {
+        assert.strictEqual(supportsVid("JPLS", "136.0"), false);
+        assert.strictEqual(supportsVid("HMN", "150.5"), false);
+        assert.strictEqual(supportsVid("HMM", "199.9"), false);
+      });
+
+      test("the 2xx line is unaffected by shape (>= 236 either way)", () => {
+        assert.strictEqual(supportsVid("JPLS", "236.5"), true);
+        assert.strictEqual(supportsVid("JPLS", "231.5"), false);
       });
     });
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -12,20 +12,27 @@ import {
 
 describe("device_matrix", () => {
   describe("supportsVid (salt-based topic encryption threshold)", () => {
-    describe("Jupiter devices (JPLS, HMM, HMN) - require firmware >= 136.0", () => {
-      test("true for JPLS at 136.0, HMM at 140, HMN at 150.5", () => {
-        assert.strictEqual(supportsVid("JPLS", "136.0"), true);
-        assert.strictEqual(supportsVid("HMM", "140.0"), true);
-        assert.strictEqual(supportsVid("HMN", "150.5"), true);
+    // Jupiter firmware is integer-valued, and only integers are asserted here:
+    // the app decides which firmware line a device is on from the *shape* of
+    // the version string (three digits starting with "1"), which the numeric
+    // steps below can only reproduce for whole numbers. A fractional version
+    // such as "150.5" would fall out of the app's 1xx line but still sits
+    // inside the 136–199 step, so asserting it would encode our model rather
+    // than the device's behavior.
+    describe("Jupiter devices (JPLS, HMM, HMN) - require firmware >= 136", () => {
+      test("true for JPLS at 136, HMM at 140, HMN at 150", () => {
+        assert.strictEqual(supportsVid("JPLS", "136"), true);
+        assert.strictEqual(supportsVid("HMM", "140"), true);
+        assert.strictEqual(supportsVid("HMN", "150"), true);
       });
 
-      test("false for JPLS at 135.9", () => {
-        assert.strictEqual(supportsVid("JPLS", "135.9"), false);
+      test("false for JPLS at 135", () => {
+        assert.strictEqual(supportsVid("JPLS", "135"), false);
       });
 
       test("case insensitive", () => {
-        assert.strictEqual(supportsVid("jpls", "136.0"), true);
-        assert.strictEqual(supportsVid("hmm", "136.0"), true);
+        assert.strictEqual(supportsVid("jpls", "136"), true);
+        assert.strictEqual(supportsVid("hmm", "136"), true);
       });
     });
 

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -70,6 +70,16 @@ export interface DeviceProfile {
    * one wins outright, so a profile carrying both hides the other value.
    */
   vidRoutes?: VidRoute[];
+  /**
+   * For families whose firmware runs in two lines, the app reads the line off
+   * the *shape* of the raw version string rather than its numeric value, so
+   * {@link vidRoutes} alone cannot place a version like `"150.5"`: it is
+   * numerically inside the first line but is not shaped like one. `shape`
+   * matches the raw versions that really are on the first line, and
+   * `endsBefore` is where the second line starts — below it, a version that
+   * does not match `shape` belongs to the second line and is not encrypted.
+   */
+  vidFirstLine?: { shape: RegExp; endsBefore: number };
   /** Exact firmware versions that enable the remote topic id on the local broker. */
   useRemoteTopicIdVersions?: number[];
   /** Inverse-forwarding policy for this family. */
@@ -113,6 +123,15 @@ const JUPITER_VID_ROUTES: VidRoute[] = [
   { since: 200, supported: false },
   { since: 236, supported: true },
 ];
+
+/**
+ * `JupiterVersionController.isRelease()` puts a device on the 1xx line only
+ * when its raw firmware string is exactly three digits starting with "1" — so
+ * "150.5" is *not* on that line even though it sits between 100 and 200.
+ * Numbers and 1xx strings agree with the steps above; this only keeps
+ * differently shaped versions out of the encrypted 1xx range.
+ */
+const JUPITER_FIRST_LINE = { shape: /^1\d\d$/, endsBefore: 200 };
 
 /** Trim + uppercase so base-type handling is done exactly one way everywhere. */
 export function normalizeType(type: string): string {
@@ -243,6 +262,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: startsWith("HMM"),
     brokerRoutes: jupiterBrokerRoutes(230),
     vidRoutes: JUPITER_VID_ROUTES,
+    vidFirstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
   {
@@ -250,6 +270,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: startsWith("HMN"),
     brokerRoutes: jupiterBrokerRoutes(230),
     vidRoutes: JUPITER_VID_ROUTES,
+    vidFirstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
   {
@@ -257,6 +278,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: startsWith("JPLS"),
     brokerRoutes: jupiterBrokerRoutes(232),
     vidRoutes: JUPITER_VID_ROUTES,
+    vidFirstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
   {
@@ -366,6 +388,19 @@ export function supportsVid(
   }
   const profile = resolveProfile(type);
   if (profile.vidRoutes) {
+    // Only the raw string carries the shape the app keys off, so check it
+    // before falling back to the numeric steps. A number reaching here is
+    // already whole in practice (`main.ts` parses the API version with
+    // parseInt) and stringifies back to the same shape the app saw.
+    const raw = String(version).trim();
+    const firstLine = profile.vidFirstLine;
+    if (
+      firstLine &&
+      parsed < firstLine.endsBefore &&
+      !firstLine.shape.test(raw)
+    ) {
+      return false;
+    }
     let supported = false;
     for (const route of profile.vidRoutes) {
       if (parsed >= route.since) {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -58,14 +58,16 @@ export interface DeviceProfile {
   brokerRoutes?: BrokerRoute[];
   /**
    * Minimum firmware for salt-based (`cq`) topic-id encryption. `0` means
-   * "always supported"; `Infinity` means "never".
+   * "always supported"; `Infinity` means "never". Omit it only when
+   * {@link vidRoutes} covers the family instead — a profile with neither never
+   * encrypts.
    */
-  vidSupportVersion: number;
+  vidSupportVersion?: number;
   /**
-   * Optional step list for families whose firmware does not encrypt in one
-   * contiguous range (see the Jupiter entries). Takes precedence over
-   * {@link vidSupportVersion} when set; ascending by `since`, and firmware
-   * below the first step is unencrypted.
+   * Step list for families whose firmware does not encrypt in one contiguous
+   * range (see the Jupiter entries), ascending by `since`, with firmware below
+   * the first step unencrypted. Set this *or* {@link vidSupportVersion}: this
+   * one wins outright, so a profile carrying both hides the other value.
    */
   vidRoutes?: VidRoute[];
   /** Exact firmware versions that enable the remote topic id on the local broker. */
@@ -240,7 +242,6 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     name: "HMM",
     matches: startsWith("HMM"),
     brokerRoutes: jupiterBrokerRoutes(230),
-    vidSupportVersion: 136,
     vidRoutes: JUPITER_VID_ROUTES,
     inverse: "auto",
   },
@@ -248,7 +249,6 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     name: "HMN",
     matches: startsWith("HMN"),
     brokerRoutes: jupiterBrokerRoutes(230),
-    vidSupportVersion: 136,
     vidRoutes: JUPITER_VID_ROUTES,
     inverse: "auto",
   },
@@ -256,7 +256,6 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     name: "JPLS",
     matches: startsWith("JPLS"),
     brokerRoutes: jupiterBrokerRoutes(232),
-    vidSupportVersion: 136,
     vidRoutes: JUPITER_VID_ROUTES,
     inverse: "auto",
   },
@@ -375,7 +374,9 @@ export function supportsVid(
     }
     return supported;
   }
-  return parsed >= profile.vidSupportVersion;
+  // A profile with neither vidRoutes nor a threshold never encrypts, rather
+  // than comparing against undefined (which would silently be false anyway).
+  return parsed >= (profile.vidSupportVersion ?? Infinity);
 }
 
 /**

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -36,6 +36,15 @@ const DEFAULT_BROKER_ROUTES: BrokerRoute[] = [
   { since: 0, broker: BROKER_2025 },
 ];
 
+/**
+ * One step of a device family's salt-based (`cq`) topic-id encryption: from
+ * firmware `since` (and up, until the next step) encryption is used or not.
+ */
+export interface VidRoute {
+  since: number;
+  supported: boolean;
+}
+
 export interface DeviceProfile {
   /** Stable name for logging/debugging (not used for matching). */
   name: string;
@@ -52,6 +61,13 @@ export interface DeviceProfile {
    * "always supported"; `Infinity` means "never".
    */
   vidSupportVersion: number;
+  /**
+   * Optional step list for families whose firmware does not encrypt in one
+   * contiguous range (see the Jupiter entries). Takes precedence over
+   * {@link vidSupportVersion} when set; ascending by `since`, and firmware
+   * below the first step is unencrypted.
+   */
+  vidRoutes?: VidRoute[];
   /** Exact firmware versions that enable the remote topic id on the local broker. */
   useRemoteTopicIdVersions?: number[];
   /** Inverse-forwarding policy for this family. */
@@ -70,6 +86,31 @@ function migrate2024to2025(migrationVersion: number): BrokerRoute[] {
 
 /** Routing for a device that always uses the 2024 broker. */
 const ALWAYS_2024: BrokerRoute[] = [{ since: 0, broker: BROKER_2024 }];
+
+/**
+ * The Jupiter family (HMM/HMN/JPLS) ships two independent firmware lines: a
+ * 1xx line and a 2xx line (e.g. Jupiter C Plus / JPLS-8H is on 2xx). The app
+ * picks its thresholds per line — `JupiterVersionController.isRelease()` is
+ * true only for a three-digit firmware starting with "1" — so a 2xx device is
+ * *not* simply "newer than" a 1xx one: it starts over on the 2024 broker with
+ * plaintext topics and migrates again at its own, much higher thresholds
+ * (#209). Expressed as version steps, both lines are covered by one table.
+ */
+function jupiterBrokerRoutes(secondLineMigration: number): BrokerRoute[] {
+  return [
+    { since: 0, broker: BROKER_2024 },
+    { since: 135, broker: BROKER_2025 },
+    { since: 200, broker: BROKER_2024 },
+    { since: secondLineMigration, broker: BROKER_2025 },
+  ];
+}
+
+/** Salt-based (`cq`) topic-id encryption for both Jupiter firmware lines. */
+const JUPITER_VID_ROUTES: VidRoute[] = [
+  { since: 136, supported: true },
+  { since: 200, supported: false },
+  { since: 236, supported: true },
+];
 
 /** Trim + uppercase so base-type handling is done exactly one way everywhere. */
 export function normalizeType(type: string): string {
@@ -198,22 +239,25 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     name: "HMM",
     matches: startsWith("HMM"),
-    brokerRoutes: migrate2024to2025(135),
+    brokerRoutes: jupiterBrokerRoutes(230),
     vidSupportVersion: 136,
+    vidRoutes: JUPITER_VID_ROUTES,
     inverse: "auto",
   },
   {
     name: "HMN",
     matches: startsWith("HMN"),
-    brokerRoutes: migrate2024to2025(135),
+    brokerRoutes: jupiterBrokerRoutes(230),
     vidSupportVersion: 136,
+    vidRoutes: JUPITER_VID_ROUTES,
     inverse: "auto",
   },
   {
     name: "JPLS",
     matches: startsWith("JPLS"),
-    brokerRoutes: migrate2024to2025(135),
+    brokerRoutes: jupiterBrokerRoutes(232),
     vidSupportVersion: 136,
+    vidRoutes: JUPITER_VID_ROUTES,
     inverse: "auto",
   },
   {
@@ -321,7 +365,17 @@ export function supportsVid(
   if (isNaN(parsed)) {
     return false;
   }
-  return parsed >= resolveProfile(type).vidSupportVersion;
+  const profile = resolveProfile(type);
+  if (profile.vidRoutes) {
+    let supported = false;
+    for (const route of profile.vidRoutes) {
+      if (parsed >= route.since) {
+        supported = route.supported;
+      }
+    }
+    return supported;
+  }
+  return parsed >= profile.vidSupportVersion;
 }
 
 /**


### PR DESCRIPTION
## Summary
Fixed message routing and topic-id encryption for Marstek Jupiter devices (JPLS, HMM, HMN) running the 2xx firmware line. These devices were not receiving device data because they require different broker and encryption thresholds than the 1xx firmware line.

## Key Changes
- **New `VidRoute` interface**: Added support for step-based encryption routing to handle non-contiguous encryption ranges, taking precedence over the simple `vidSupportVersion` threshold
- **New `jupiterBrokerRoutes()` function**: Implements dual-line broker routing where the 2xx firmware line restarts on the 2024 broker (at fw 200) and migrates to 2025 at different thresholds per device (230 for HMM/HMN, 232 for JPLS)
- **New `JUPITER_VID_ROUTES` constant**: Defines encryption support for both Jupiter lines:
  - 1xx line: encrypted from fw 136+
  - 2xx line: plaintext from fw 200-235, encrypted from fw 236+
- **Updated device profiles**: HMM, HMN, and JPLS now use `jupiterBrokerRoutes()` and `JUPITER_VID_ROUTES` instead of simple single-threshold values
- **Enhanced `supportsVid()` logic**: Now checks `vidRoutes` array first (if present) to determine encryption support, falling back to `vidSupportVersion` for devices without step-based routing
- **Documentation**: Added "Jupiter firmware lines" section explaining the dual-line architecture and updated the device matrix table to clarify 1xx vs 2xx behavior

## Implementation Details
The Jupiter family ships two independent firmware lines that don't follow a simple "newer is better" progression. A 2xx device at fw 231 is on the 2024 broker without encryption, while a 1xx device at fw 136 is already on the 2025 broker with encryption. The solution uses version steps to express both lines in a single routing table, with the 2xx line "restarting" at fw 200 on the 2024 broker.

https://claude.ai/code/session_01AM8HvyzoQgYLcVbNz74ooJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed device data handling for Marstek Jupiter devices on 2xx firmware, restoring proper reverse-path reporting so entities can be created.
  * Improved device compatibility checks to correctly apply broker routing and topic encryption behavior across Jupiter’s independent 1xx and 2xx firmware lines.

* **Documentation**
  * Updated the device support matrix to split Jupiter device families into separate 1xx and 2xx firmware rows with the correct migration thresholds.
  * Added a clarification section explaining that “newer” Jupiter firmware numbers don’t automatically mean a later broker/encryption state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->