### PR TITLE
Support HME meters' second firmware line with lower encryption thresholds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [Next]
 - Add support for the Marstek CT002 new generation (device type `TPM2-0`) (#201)
 - Fixed Marstek Jupiter devices (JPLS, HMM, HMN) on firmware 2xx never receiving device data: messages were forwarded to the app but nothing came back, so no entities were created. Jupiter ships two separate firmware lines and the 2xx line needs different handling than the 1xx line (#209)
+- Fixed Marstek HME-2/HME-3/HME-4/HME-5 meters (e.g. CT003) on a two-digit firmware version never receiving device data, so no entities were created. Like Jupiter, these meters ship two separate firmware lines, and the second one needs different handling (#212)
 
 
 ## [1.4.3] - 2026-06-13

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -45,8 +45,10 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMD-V, HMD-N        | hame-2025                   | never | —               | auto        | V6000 / M5000 outdoor power |
 | HMD (other)         | hame-2024 → hame-2025 @155  | never | —               | auto        | outdoor power station |
 | HME (base / other)  | hame-2024                   | never | —               | auto        | AstraMeter family; non-2/3/4/5 |
-| HME-2, HME-4        | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family |
-| HME-3, HME-5        | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
+| HME-2, HME-4 (3-digit fw) | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family; see "HME firmware lines" |
+| HME-2, HME-4 (other fw)   | hame-2024 → hame-2025 @24   | 25    | —               | auto        | |
+| HME-3, HME-5 (3-digit fw) | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
+| HME-3, HME-5 (other fw)   | hame-2024 → hame-2025 @33   | 34    | —               | auto        | |
 | TPM-CN              | hame-2025                   | 101   | —               | auto        | standalone identifier |
 | TPM2                | hame-2025                   | 0     | —               | auto        | CT002 new generation (`TPM2-0`, #201) |
 | HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | |
@@ -64,6 +66,16 @@ firmware is not simply "newer" than a 1xx one: the line starts over on the 2024
 broker with plaintext topic ids and migrates again at its own thresholds. So a
 JPLS on fw 231 is on the 2024 broker without topic encryption, while the same
 family on fw 136 is already on the 2025 broker with encrypted topic ids.
+
+## HME firmware lines
+
+The HME meters (HME-2/HME-4 and HME-3/HME-5) have the same two-line split. The
+line is picked from the *length* of the firmware version string: a three-digit
+version (`116`, `119`) is on the main line, any other length (a two-digit
+version such as `50`, or a four-digit one) is on the second line, which reached
+the 2025 broker and encrypted topic ids at much lower versions. So an HME-2 on
+fw 50 is on the 2025 broker with encrypted topic ids, while the same meter on
+fw 100 is back on the 2024 broker with plaintext ones (#212).
 
 ## Matching precedence
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -87,13 +87,13 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("HME-2, HME-4 - require firmware >= 122.0", () => {
+    describe("HME-2, HME-4 - main firmware line requires >= 122", () => {
       test("true at/above 122", () => {
-        assert.strictEqual(supportsVid("HME-2", "122.0"), true);
-        assert.strictEqual(supportsVid("HME-4", "125.0"), true);
+        assert.strictEqual(supportsVid("HME-2", "122"), true);
+        assert.strictEqual(supportsVid("HME-4", "125"), true);
       });
       test("false below 122", () => {
-        assert.strictEqual(supportsVid("HME-2", "121.9"), false);
+        assert.strictEqual(supportsVid("HME-2", "121"), false);
       });
     });
 
@@ -118,17 +118,45 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("HME-3, HME-5 - require firmware >= 120.0", () => {
+    describe("HME-3, HME-5 - main firmware line requires >= 120", () => {
       test("true at/above 120", () => {
-        assert.strictEqual(supportsVid("HME-3", "120.0"), true);
-        assert.strictEqual(supportsVid("HME-5", "125.0"), true);
+        assert.strictEqual(supportsVid("HME-3", "120"), true);
+        assert.strictEqual(supportsVid("HME-5", "125"), true);
       });
       test("false below 120", () => {
-        assert.strictEqual(supportsVid("HME-3", "119.9"), false);
-        assert.strictEqual(supportsVid("HME-5", "115.0"), false);
+        assert.strictEqual(supportsVid("HME-3", "119"), false);
+        assert.strictEqual(supportsVid("HME-5", "115"), false);
         // At the broker-migration fw (116) the meter moves to the 2025 broker
         // but still does not encrypt topic ids (#145): thresholds are distinct.
         assert.strictEqual(supportsVid("HME-3", "116"), false);
+      });
+    });
+
+    describe("HME second firmware line - much lower thresholds (#212)", () => {
+      test("HME-2/HME-4 encrypt from 25 on the second line", () => {
+        assert.strictEqual(supportsVid("HME-2", "24"), false);
+        assert.strictEqual(supportsVid("HME-2", "25"), true);
+        assert.strictEqual(supportsVid("HME-4", "50"), true);
+        assert.strictEqual(supportsVid("HME-2", "99"), true);
+      });
+
+      test("HME-3/HME-5 encrypt from 34 on the second line", () => {
+        assert.strictEqual(supportsVid("HME-3", "33"), false);
+        assert.strictEqual(supportsVid("HME-3", "34"), true);
+        assert.strictEqual(supportsVid("HME-5", "50"), true);
+        assert.strictEqual(supportsVid("HME-3", "99"), true);
+      });
+
+      test("the main line starts over unencrypted at 100", () => {
+        assert.strictEqual(supportsVid("HME-2", "100"), false);
+        assert.strictEqual(supportsVid("HME-3", "100"), false);
+      });
+
+      // Four-digit versions are on the second line again, where everything
+      // from 25 / 34 up is encrypted.
+      test("four-digit versions stay encrypted", () => {
+        assert.strictEqual(supportsVid("HME-2", "1000"), true);
+        assert.strictEqual(supportsVid("HME-3", "1000"), true);
       });
     });
 
@@ -270,16 +298,32 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("JPLS-8H", 199), "hame-2025");
     });
 
-    test("HME-2/HME-4: hame-2024 below 119, hame-2025 at/above (#145)", () => {
+    test("HME-2/HME-4 main line: hame-2024 below 119, hame-2025 at/above (#145)", () => {
       assert.strictEqual(brokerForVersion("HME-2", 118), "hame-2024");
       assert.strictEqual(brokerForVersion("HME-2", 119), "hame-2025");
       assert.strictEqual(brokerForVersion("HME-4", 119), "hame-2025");
     });
 
-    test("HME-3/HME-5: hame-2024 below 116, hame-2025 at/above (#145)", () => {
+    test("HME-3/HME-5 main line: hame-2024 below 116, hame-2025 at/above (#145)", () => {
       assert.strictEqual(brokerForVersion("HME-3", 115), "hame-2024");
       assert.strictEqual(brokerForVersion("HME-3", 116), "hame-2025");
       assert.strictEqual(brokerForVersion("HME-5", 116), "hame-2025");
+    });
+
+    test("HME second firmware line migrates far earlier (#212)", () => {
+      // HME-2/HME-4 at 24, HME-3/HME-5 at 33 — then the main line starts over
+      // on the 2024 broker at 100.
+      assert.strictEqual(brokerForVersion("HME-2", 23), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME-2", 24), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-4", 99), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-2", 100), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME-3", 32), "hame-2024");
+      assert.strictEqual(brokerForVersion("HME-3", 33), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-5", 99), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-3", 100), "hame-2024");
+      // Four-digit versions are back on the second line, long since migrated.
+      assert.strictEqual(brokerForVersion("HME-2", 1000), "hame-2025");
+      assert.strictEqual(brokerForVersion("HME-3", 1000), "hame-2025");
     });
 
     test("HMB: always hame-2024 (never migrates to the 2025 broker)", () => {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -65,9 +65,10 @@ export interface DeviceProfile {
   vidSupportVersion?: number;
   /**
    * Step list for families whose firmware does not encrypt in one contiguous
-   * range (see the Jupiter entries), ascending by `since`, with firmware below
-   * the first step unencrypted. Set this *or* {@link vidSupportVersion}: this
-   * one wins outright, so a profile carrying both hides the other value.
+   * range (see the Jupiter and HME entries), ascending by `since`, with
+   * firmware below the first step unencrypted. Set this *or*
+   * {@link vidSupportVersion}: this one wins outright, so a profile carrying
+   * both hides the other value.
    */
   vidRoutes?: VidRoute[];
   /**
@@ -133,6 +134,47 @@ const JUPITER_VID_ROUTES: VidRoute[] = [
  */
 const JUPITER_FIRST_LINE = { shape: /^1\d\d$/, endsBefore: 200 };
 
+/**
+ * Where the HME meters' main firmware line starts. `CtVersionController` reads
+ * the line off the *length* of the raw version string: a three-character
+ * version ("116", "119") is on the main line, anything else — a two-digit
+ * version such as "50", or a four-digit one — is on the second line. For whole
+ * versions that is exactly the range 100–999, so the numeric steps below
+ * reproduce the app's choice; only a fractional version inside that range
+ * would need the {@link DeviceProfile.vidFirstLine} treatment, and HME
+ * firmware is always reported whole.
+ */
+const HME_MAIN_LINE_START = 100;
+
+/**
+ * Broker routing for an HME meter across both of its firmware lines (#212).
+ * Like the Jupiter family, a main-line firmware is not simply "newer" than a
+ * second-line one: the second line migrated to the 2025 broker at a far lower
+ * version, and the main line starts over on the 2024 broker at 100. Above 999
+ * the second line resumes, where both thresholds are long since passed and the
+ * last step already says 2025.
+ */
+function hmeBrokerRoutes(
+  secondLineMigration: number,
+  mainLineMigration: number,
+): BrokerRoute[] {
+  return [
+    { since: 0, broker: BROKER_2024 },
+    { since: secondLineMigration, broker: BROKER_2025 },
+    { since: HME_MAIN_LINE_START, broker: BROKER_2024 },
+    { since: mainLineMigration, broker: BROKER_2025 },
+  ];
+}
+
+/** Salt-based (`cq`) topic-id encryption across both HME firmware lines. */
+function hmeVidRoutes(secondLineVid: number, mainLineVid: number): VidRoute[] {
+  return [
+    { since: secondLineVid, supported: true },
+    { since: HME_MAIN_LINE_START, supported: false },
+    { since: mainLineVid, supported: true },
+  ];
+}
+
 /** Trim + uppercase so base-type handling is done exactly one way everywhere. */
 export function normalizeType(type: string): string {
   return type.trim().toUpperCase();
@@ -158,16 +200,16 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     name: "HME-2/HME-4",
     matches: exact("HME-2", "HME-4"),
-    brokerRoutes: migrate2024to2025(119),
-    vidSupportVersion: 122,
+    brokerRoutes: hmeBrokerRoutes(24, 119),
+    vidRoutes: hmeVidRoutes(25, 122),
     inverse: "auto",
     astraMeter: true,
   },
   {
     name: "HME-3/HME-5",
     matches: exact("HME-3", "HME-5"),
-    brokerRoutes: migrate2024to2025(116),
-    vidSupportVersion: 120,
+    brokerRoutes: hmeBrokerRoutes(33, 116),
+    vidRoutes: hmeVidRoutes(34, 120),
     inverse: "auto",
     astraMeter: true,
   },


### PR DESCRIPTION
## Summary
Add support for HME meters (HME-2/HME-4 and HME-3/HME-5) that operate on a second firmware line with significantly lower broker migration and topic-id encryption thresholds. The firmware line is determined by version string length: three-digit versions are on the main line, while two-digit and four-digit versions are on the second line.

## Key Changes
- **New helper functions** in `device_matrix.ts`:
  - `hmeBrokerRoutes()`: Generates broker routing rules accounting for both firmware lines, where the second line migrates to hame-2025 at much lower versions (24 for HME-2/4, 33 for HME-3/5), and the main line restarts on hame-2024 at version 100
  - `hmeVidRoutes()`: Generates topic-id encryption routes for both firmware lines with separate thresholds

- **Updated device profiles** for HME-2/HME-4 and HME-3/HME-5:
  - Replaced simple `vidSupportVersion` with `vidRoutes` to handle non-contiguous encryption ranges
  - Replaced simple `migrate2024to2025()` with `hmeBrokerRoutes()` to handle the dual-line behavior

- **Documentation updates**:
  - Expanded device matrix table to show both firmware lines separately
  - Added "HME firmware lines" section explaining the two-line split and how it's determined by version string length
  - Updated test descriptions to clarify "main firmware line" vs. second line behavior

## Implementation Details
The solution mirrors the existing Jupiter family pattern where firmware versions don't follow a simple linear progression. HME meters have a "main line" (100–999 digit versions) and a "second line" (2-digit and 4+ digit versions) that migrated to the 2025 broker independently. The main line starts unencrypted at version 100, requiring separate routing and encryption rules for each line.

https://claude.ai/code/session_01CNJpjB5kKoWQpzDHPSR1bA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing device data and entity creation for Marstek HME-2/HME-3/HME-4/HME-5 meters with two-digit firmware versions.
  * Improved broker selection and topic-ID encryption handling across supported HME firmware lines.

* **Documentation**
  * Updated the device support matrix with firmware-specific broker and encryption requirements.
  * Documented how firmware version formats determine device routing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->