### PR TITLE
Expand device support: add HMD-N, SMR, HMC/SCH/HML/UB, and more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 - Add support for the Marstek CT002 new generation (device type `TPM2-0`) (#201)
 - Fixed Marstek Jupiter devices (JPLS, HMM, HMN) on firmware 2xx never receiving device data: messages were forwarded to the app but nothing came back, so no entities were created. Jupiter ships two separate firmware lines and the 2xx line needs different handling than the 1xx line (#209)
 - Fixed Marstek HME-2/HME-3/HME-4/HME-5 meters (e.g. CT003) on a two-digit firmware version never receiving device data, so no entities were created. Like Jupiter, these meters ship two separate firmware lines, and the second one needs different handling (#212)
+- Fixed HMD outdoor power stations (`HMD-1`…`HMD-7`, `HMD-41/61/71/72`) losing all traffic after a firmware update to 155 or later. These models stay on the legacy broker at every firmware; only the `HMD-V` and `HMD-N` variants ever moved (#214)
+- Fixed the `HMI-350S`, `HMI-500S` and `HMI-02KS` inverters being treated as regular HMI devices, which put them on the wrong broker and used the wrong topic ids above certain firmware versions (#214)
+- Added support for several device types that previously could not be forwarded at all: `HMC` and `SCH-1` (M5000), `HML`, `UB` and the Venus G PV (`VNSGPV`) (#214)
+- Fixed the Mars (`HMH`), M5000 (`SDH`), Venus X (`VENX`), Venus G (`VNSG`), Venus E Mini (`VNSEMINI`), `VNSB` and `VAAC2` devices using encrypted topic ids they do not support, and the US/CH Venus 3 variants (`VNSE3US`/`VNSE3CH`) not using them below firmware 123 (#214)
+- Devices reporting a firmware version with a decimal point are no longer rounded down, which could select the wrong broker or topic format (#214)
+- Removed the spurious "Unknown device type" warning on startup for a range of supported devices (#214)
 
 
 ## [1.4.3] - 2026-06-13

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,12 @@
 - Add support for the Marstek CT002 new generation (device type `TPM2-0`) (#201)
 - Fixed Marstek Jupiter devices (JPLS, HMM, HMN) on firmware 2xx never receiving device data: messages were forwarded to the app but nothing came back, so no entities were created. Jupiter ships two separate firmware lines and the 2xx line needs different handling than the 1xx line (#209)
 - Fixed Marstek HME-2/HME-3/HME-4/HME-5 meters (e.g. CT003) on a two-digit firmware version never receiving device data, so no entities were created. Like Jupiter, these meters ship two separate firmware lines, and the second one needs different handling (#212)
-- Fixed HMD outdoor power stations (`HMD-1`…`HMD-7`, `HMD-41/61/71/72`) losing all traffic after a firmware update to 155 or later. These models stay on the legacy broker at every firmware; only the `HMD-V` and `HMD-N` variants ever moved (#214)
-- Fixed the `HMI-350S`, `HMI-500S` and `HMI-02KS` inverters being treated as regular HMI devices, which put them on the wrong broker and used the wrong topic ids above certain firmware versions (#214)
-- Added support for several device types that previously could not be forwarded at all: `HMC` and `SCH-1` (M5000), `HML`, `UB` and the Venus G PV (`VNSGPV`) (#214)
-- Fixed the Mars (`HMH`), M5000 (`SDH`), Venus X (`VENX`), Venus G (`VNSG`), Venus E Mini (`VNSEMINI`), `VNSB` and `VAAC2` devices using encrypted topic ids they do not support, and the US/CH Venus 3 variants (`VNSE3US`/`VNSE3CH`) not using them below firmware 123 (#214)
-- Devices reporting a firmware version with a decimal point are no longer rounded down, which could select the wrong broker or topic format (#214)
-- Removed the spurious "Unknown device type" warning on startup for a range of supported devices (#214)
+- Fixed HMD outdoor power stations losing all traffic after a recent firmware update, so no entities were created. Only the HMD-V and HMD-N variants were ever meant to switch (#214)
+- Fixed the HMI-350S, HMI-500S and HMI-02KS inverters being treated as regular HMI devices, which stopped them receiving device data on newer firmware (#214)
+- Added support for several device types that could not be forwarded at all: Marstek M5000 (HMC, SCH), HML, UB and Venus G PV (#214)
+- Fixed Mars (HMH), M5000 (SDH), Venus X, Venus G, Venus E Mini, VNSB and VAAC2 devices not responding to control requests, and the same on the US and CH variants of Venus 3 on older firmware (#214)
+- Fixed devices whose firmware version contains a decimal point being handled as if they were on a much older firmware (#214)
+- Removed the spurious "Unknown device type" warning on startup for many supported devices (#214)
 
 
 ## [1.4.3] - 2026-06-13

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -42,21 +42,33 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMN (2xx firmware)  | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
 | JPLS (1xx firmware) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | `JPLS-NH` |
 | JPLS (2xx firmware) | hame-2024 → hame-2025 @232  | 236   | —               | auto        | e.g. Jupiter C Plus, #209 |
-| HMD-V, HMD-N        | hame-2025                   | never | —               | auto        | V6000 / M5000 outdoor power |
-| HMD (other)         | hame-2024 → hame-2025 @155  | never | —               | auto        | outdoor power station |
+| HMD-V               | hame-2025                   | never | —               | auto        | outdoor power station |
+| HMD-N               | hame-2024 → hame-2025 @1.42 | never | —               | auto        | outdoor power station |
+| HMD (other)         | hame-2024                   | never | —               | auto        | `HMD-1`…`HMD-7`, `HMD-41/61/71/72`, bare `HMD`; never offered the 2025 broker |
 | HME (base / other)  | hame-2024                   | never | —               | auto        | AstraMeter family; non-2/3/4/5 |
 | HME-2, HME-4 (3-digit fw) | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family; see "HME firmware lines" |
 | HME-2, HME-4 (other fw)   | hame-2024 → hame-2025 @24   | 25    | —               | auto        | |
 | HME-3, HME-5 (3-digit fw) | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
 | HME-3, HME-5 (other fw)   | hame-2024 → hame-2025 @33   | 34    | —               | auto        | |
 | TPM-CN              | hame-2025                   | 101   | —               | auto        | standalone identifier |
-| TPM2                | hame-2025                   | 0     | —               | auto        | CT002 new generation (`TPM2-0`, #201) |
-| HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | |
-| HMI-2000            | hame-2024 → hame-2025 @113  | 105   | —               | auto        | 4-PV microinverter |
-| HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", see #158 / #164 |
+| TPM2-0              | hame-2025                   | 0     | —               | auto        | CT002 new generation (#201) |
+| TPM2 (other)        | hame-2024                   | never | —               | auto        | unrecognised; only `TPM2-0` ships today |
+| SMR-0, SMR-1, SMR-2 | hame-2025                   | 0     | —               | auto        | CT003 meter readers: P1 (NL) / IR (DE) / TIC (FR) |
+| HMI-2000, HMI-02KS  | hame-2024 → hame-2025 @113  | 105   | —               | auto        | "route 4"; 4-PV microinverter |
+| HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", incl. `HMI-350S` / `HMI-500S`; see #158 / #164 |
+| HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | "route 2": any remaining HMI id containing a digit 1-5 |
+| HMI (other)         | hame-2024                   | never | —               | auto        | "route 0", e.g. `HMI-6` |
+| HMC, SCH, HML, UB   | hame-2024                   | never | —               | auto        | M5000 (`HMC-1/2/7`, `SCH-1`), Mars-A (other HMC) |
+| HMHL                | hame-2025                   | 0     | —               | auto        | Mars SE |
+| SDH-6K              | hame-2025                   | 0     | —               | auto        | V6000 |
+| HMH, SDH, VENX      | hame-2025                   | never | —               | auto        | Mars, M5000 (other SDH), Venus X |
 | VNSD, VNSA (incl. VNSD2, VNSA2) | hame-2025      | 123   | —               | auto        | Venus series; always 2025 |
-| VNSE3, VNSE4        | hame-2025                   | 123   | —               | auto        | Venus series |
-| _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device |
+| VNSE3, VNSE3AU, VNSE4, VNSEMAX | hame-2025       | 123   | —               | auto        | Venus series |
+| VNSE3US, VNSE3CH    | hame-2025                   | 0     | —               | auto        | Venus series; encrypts unconditionally |
+| VNSGPV              | hame-2024                   | never | —               | auto        | Venus G PV; unlike its VNSG sibling |
+| VNSG, VNSEMINI, VNSB | hame-2025                  | never | —               | auto        | VNS-prefixed but not Venus devices |
+| VAAC2               | hame-2025                   | never | —               | auto        | |
+| _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device; incl. `VEPRO`, `VDAC` |
 
 ## Jupiter firmware lines
 
@@ -81,15 +93,20 @@ fw 100 is back on the 2024 broker with plaintext ones (#212).
 
 A device type is matched most-specific first:
 
-1. Exact identifiers — `HME-2`/`HME-4`, `HME-3`/`HME-5`, `TPM-CN`.
-2. Model-token rules (must precede their base prefix):
-   - `HMI-350`/`HMI-500` and `HMI-2000`, matched on a whole number token so ids
-     like `HMI-3500`, `HMI-5000`, `HMI-12000` or `HMI-20001` fall through to the
-     regular HMI profile.
-   - `HMD-V*`/`HMD-N*` (V6000 / M5000 sub-types) before base `HMD`.
-3. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
-   `JPLS`, `HMD`, `HME`, `HMI`, `TPM2`, `VNS`.
-4. Unknown — assume a `hame-2025`, topic-encryption-capable device.
+1. Exact identifiers — `HME-2`/`HME-4`, `HME-3`/`HME-5`, `TPM-CN`, `TPM2-0`.
+2. HMI routes, tested in the order 4 → 1 → 2 → 0. The app classifies an HMI id
+   by plain **substring**, not by whole token, and checks `2000`/`02KS` before
+   `350`/`500` — so `HMI-3500` is route 1 and `HMI-12000` is route 4, not the
+   regular HMI profile.
+3. Sub-type rules that must precede their base prefix:
+   - `HMD-V*` and `HMD-N*` before base `HMD`.
+   - `HMHL` before `HMH`.
+   - `SDH-6K` before `SDH`.
+   - `VNSGPV` before `VNSG`.
+4. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
+   `JPLS`, `HMD`, `HME`, `HMH`, `SDH`, `VENX`, `SMR-`, `HMC`, `SCH`, `HML`,
+   `UB`, `TPM2`, `VNS`, `VAAC2`.
+5. Unknown — assume a `hame-2025`, topic-encryption-capable device.
 
 ## AstraMeter placeholder devices
 

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -102,7 +102,8 @@ A device type is matched most-specific first:
    - `HMD-V*` and `HMD-N*` before base `HMD`.
    - `HMHL` before `HMH`.
    - `SDH-6K` before `SDH`.
-   - `VNSGPV` before `VNSG`.
+   - `VNSE3US`/`VNSE3CH` before `VNS`.
+   - `VNSGPV` before `VNSG`, and both before `VNS`.
 4. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
    `JPLS`, `HMD`, `HME`, `HMH`, `SDH`, `VENX`, `SMR-`, `HMC`, `SCH`, `HML`,
    `UB`, `TPM2`, `VNS`, `VAAC2`.

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -116,6 +116,10 @@ describe("device_matrix", () => {
       test("case insensitive", () => {
         assert.strictEqual(supportsVid("tpm2-0", "105.0"), true);
       });
+      test("only the exact TPM2-0 id is recognized", () => {
+        assert.strictEqual(supportsVid("TPM2-1", "105.0"), false);
+        assert.strictEqual(supportsVid("TPM2-1", "999.0"), false);
+      });
     });
 
     describe("HME-3, HME-5 - main firmware line requires >= 120", () => {
@@ -183,23 +187,32 @@ describe("device_matrix", () => {
     });
 
     describe("HMI devices", () => {
-      test("HMI-2000 from 105", () => {
+      test("route 4 (HMI-2000 / HMI-02KS) from 105", () => {
         assert.strictEqual(supportsVid("HMI-2000", "105.0"), true);
         assert.strictEqual(supportsVid("HMI-2000", "104.9"), false);
+        assert.strictEqual(supportsVid("HMI-02KS", "105.0"), true);
+        assert.strictEqual(supportsVid("HMI-02KS", "104.9"), false);
       });
-      test("other HMI from 120", () => {
+      test("route 2 (regular HMI) from 120", () => {
         assert.strictEqual(supportsVid("HMI-1", "120.0"), true);
         assert.strictEqual(supportsVid("HMI-1", "119.9"), false);
       });
-      test("HMI-350 / HMI-500 never support topic encryption", () => {
-        assert.strictEqual(supportsVid("HMI-350", "120.0"), false);
-        assert.strictEqual(supportsVid("HMI-350", "999.0"), false);
-        assert.strictEqual(supportsVid("HMI-500", "120.0"), false);
-        assert.strictEqual(supportsVid("HMI-500", "999.0"), false);
+      test("route 1 (HMI-350 / HMI-500, incl. the S models) never encrypts", () => {
+        for (const type of ["HMI-350", "HMI-500", "HMI-350S", "HMI-500S"]) {
+          assert.strictEqual(supportsVid(type, "120.0"), false, type);
+          assert.strictEqual(supportsVid(type, "999.0"), false, type);
+        }
       });
-      test("ids containing 350/500 as a substring stay on the regular HMI path", () => {
-        assert.strictEqual(supportsVid("HMI-3500", "120.0"), true);
-        assert.strictEqual(supportsVid("HMI-5000", "119.9"), false);
+      test("route 0 (e.g. HMI-6) never encrypts", () => {
+        assert.strictEqual(supportsVid("HMI-6", "120.0"), false);
+        assert.strictEqual(supportsVid("HMI-6", "999.0"), false);
+      });
+      // The app classifies by substring, so an id merely containing 350/500 or
+      // 2000 takes that route rather than the regular HMI one.
+      test("substring matching decides the route", () => {
+        assert.strictEqual(supportsVid("HMI-3500", "999.0"), false);
+        assert.strictEqual(supportsVid("HMI-5000", "999.0"), false);
+        assert.strictEqual(supportsVid("HMI-12000", "105.0"), true);
       });
     });
 
@@ -215,6 +228,50 @@ describe("device_matrix", () => {
       test("case insensitive", () => {
         assert.strictEqual(supportsVid("vnse3", "123.0"), true);
         assert.strictEqual(supportsVid("vnsa", "122.9"), false);
+      });
+      test("VNSE3US / VNSE3CH encrypt unconditionally", () => {
+        assert.strictEqual(supportsVid("VNSE3US", "0"), true);
+        assert.strictEqual(supportsVid("VNSE3US", "122.9"), true);
+        assert.strictEqual(supportsVid("VNSE3CH", "122.9"), true);
+        // VNSE3AU is a plain Venus and keeps the 123 threshold.
+        assert.strictEqual(supportsVid("VNSE3AU", "122.9"), false);
+        assert.strictEqual(supportsVid("VNSE3AU", "123.0"), true);
+      });
+      test("VNS-prefixed non-Venus devices never encrypt", () => {
+        for (const type of ["VNSG-0", "VNSGPV-0", "VNSEMINI-0", "VNSB-0"]) {
+          assert.strictEqual(supportsVid(type, "999.0"), false, type);
+        }
+      });
+      test("VAAC2 never encrypts", () => {
+        assert.strictEqual(supportsVid("VAAC2-0", "999.0"), false);
+      });
+    });
+
+    describe("families that never encrypt", () => {
+      test("HMC / SCH / HML / UB", () => {
+        for (const type of ["HMC-1", "HMC-3", "SCH-1", "HML-0", "UB-0"]) {
+          assert.strictEqual(supportsVid(type, "999.0"), false, type);
+        }
+      });
+      test("HMH / SDH / VENX, but not HMHL or SDH-6K", () => {
+        for (const type of ["HMH-0", "SDH-0", "VENX-0"]) {
+          assert.strictEqual(supportsVid(type, "999.0"), false, type);
+        }
+        assert.strictEqual(supportsVid("HMHL-0", "0"), true);
+        assert.strictEqual(supportsVid("SDH-6K", "0"), true);
+      });
+      test("HMD never encrypts on any sub-type or firmware", () => {
+        for (const type of ["HMD-1", "HMD-41", "HMD-V1", "HMD-N1", "HMD"]) {
+          assert.strictEqual(supportsVid(type, "999.0"), false, type);
+        }
+      });
+    });
+
+    describe("SMR (CT003 meter readers) - always topic-encryption capable", () => {
+      test("true at any firmware", () => {
+        for (const type of ["SMR-0", "SMR-1", "SMR-2"]) {
+          assert.strictEqual(supportsVid(type, "0"), true, type);
+        }
       });
     });
 
@@ -331,24 +388,32 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMB-1", 999), "hame-2024");
     });
 
-    test("HMI-350 / HMI-500 are always hame-2024 (route 1)", () => {
-      assert.strictEqual(brokerForVersion("HMI-350", 0), "hame-2024");
-      assert.strictEqual(brokerForVersion("HMI-350", 999), "hame-2024");
-      assert.strictEqual(brokerForVersion("HMI-500", 999), "hame-2024");
+    test("route 1 (HMI-350 / HMI-500, incl. the S models) is always hame-2024", () => {
+      for (const type of ["HMI-350", "HMI-500", "HMI-350S", "HMI-500S"]) {
+        assert.strictEqual(brokerForVersion(type, 0), "hame-2024", type);
+        assert.strictEqual(brokerForVersion(type, 999), "hame-2024", type);
+      }
       assert.strictEqual(brokerForVersion(" hmi-350 ", 999), "hame-2024");
+      // Substring matching: HMI-3500 / HMI-5000 are route-1 too.
+      assert.strictEqual(brokerForVersion("HMI-3500", 999), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMI-5000", 999), "hame-2024");
     });
 
-    test("HMI (regular): hame-2024 below 129, hame-2025 at/above (#173)", () => {
+    test("route 2 (regular HMI): hame-2024 below 129, hame-2025 at/above (#173)", () => {
       assert.strictEqual(brokerForVersion("HMI-1", 128), "hame-2024");
       assert.strictEqual(brokerForVersion("HMI-1", 129), "hame-2025");
-      // HMI-3500 / HMI-5000 are not route-1 devices; they follow regular HMI.
-      assert.strictEqual(brokerForVersion("HMI-3500", 128), "hame-2024");
-      assert.strictEqual(brokerForVersion("HMI-3500", 129), "hame-2025");
     });
 
-    test("HMI-2000: hame-2024 below 113, hame-2025 at/above", () => {
-      assert.strictEqual(brokerForVersion("HMI-2000", 112), "hame-2024");
-      assert.strictEqual(brokerForVersion("HMI-2000", 113), "hame-2025");
+    test("route 0 (e.g. HMI-6) is always hame-2024", () => {
+      assert.strictEqual(brokerForVersion("HMI-6", 0), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMI-6", 999), "hame-2024");
+    });
+
+    test("route 4 (HMI-2000 / HMI-02KS): hame-2024 below 113, hame-2025 at/above", () => {
+      for (const type of ["HMI-2000", "HMI-02KS", "HMI-12000"]) {
+        assert.strictEqual(brokerForVersion(type, 112), "hame-2024", type);
+        assert.strictEqual(brokerForVersion(type, 113), "hame-2025", type);
+      }
     });
 
     test("HME base (non-2/3/4/5) is always hame-2024", () => {
@@ -357,14 +422,38 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HME", 999), "hame-2024");
     });
 
-    test("HMD-V/HMD-N always hame-2025; other HMD migrates at 155", () => {
+    test("HMD-V is always hame-2025", () => {
       assert.strictEqual(brokerForVersion("HMD-V1", 0), "hame-2025");
-      assert.strictEqual(brokerForVersion("HMD-N1", 0), "hame-2025");
-      assert.strictEqual(brokerForVersion("HMD-1", 154), "hame-2024");
-      assert.strictEqual(brokerForVersion("HMD-1", 155), "hame-2025");
-      // Non-target HMD ids (no V/N sub-type token) follow the base HMD route.
-      assert.strictEqual(brokerForVersion("HMD-41", 154), "hame-2024");
-      assert.strictEqual(brokerForVersion("HMD-41", 155), "hame-2025");
+      assert.strictEqual(brokerForVersion("HMD-V1", 999), "hame-2025");
+    });
+
+    test("HMD-N: hame-2024 below 1.42, hame-2025 at/above", () => {
+      assert.strictEqual(brokerForVersion("HMD-N1", 1.41), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMD-N1", 1.42), "hame-2025");
+      assert.strictEqual(brokerForVersion("HMD-N1", 142), "hame-2025");
+    });
+
+    test("all other HMD ids are always hame-2024 (no 155 threshold)", () => {
+      for (const type of ["HMD-1", "HMD-7", "HMD-41", "HMD-72", "HMD"]) {
+        assert.strictEqual(brokerForVersion(type, 154), "hame-2024", type);
+        assert.strictEqual(brokerForVersion(type, 155), "hame-2024", type);
+        assert.strictEqual(brokerForVersion(type, 999), "hame-2024", type);
+      }
+    });
+
+    test("families that never reached the 2025 broker", () => {
+      for (const type of [
+        "HMC-1",
+        "HMC-3",
+        "SCH-1",
+        "HML-0",
+        "UB-0",
+        "VNSGPV-0",
+        "TPM2-1",
+      ]) {
+        assert.strictEqual(brokerForVersion(type, 0), "hame-2024", type);
+        assert.strictEqual(brokerForVersion(type, 999), "hame-2024", type);
+      }
     });
 
     test("all Venus VNS* types are always hame-2025 (no 2024 migration)", () => {
@@ -394,8 +483,17 @@ describe("device_matrix", () => {
         "VNSE4-0",
         "VDAC-0",
         "VAAC2-0",
+        "VEPRO-0",
+        "VNSG-0",
+        "VNSEMINI-0",
+        "VNSB-0",
+        "VENX-0",
         "HMD-V1",
-        "HMD-N1",
+        "HMH-0",
+        "HMHL-0",
+        "SDH-0",
+        "SDH-6K",
+        "SMR-0",
         "TPM-CN",
         "TPM2-0",
         "UNKNOWN-9",
@@ -470,16 +568,54 @@ describe("device_matrix", () => {
   });
 
   describe("resolveProfile precedence", () => {
-    test("HMI token rules beat the HMI base entry", () => {
+    test("HMI routes are tested 4 -> 1 -> 2 -> 0", () => {
       assert.strictEqual(
         resolveProfile("HMI-350").name,
         "HMI-350/HMI-500 (route 1)",
       );
-      assert.strictEqual(resolveProfile("HMI-2000").name, "HMI-2000");
-      assert.strictEqual(resolveProfile("HMI-1").name, "HMI");
-      // substring-only ids fall through to the regular HMI profile
-      assert.strictEqual(resolveProfile("HMI-3500").name, "HMI");
-      assert.strictEqual(resolveProfile("HMI-12000").name, "HMI");
+      assert.strictEqual(
+        resolveProfile("HMI-350S").name,
+        "HMI-350/HMI-500 (route 1)",
+      );
+      assert.strictEqual(
+        resolveProfile("HMI-2000").name,
+        "HMI-2000/HMI-02KS (route 4)",
+      );
+      assert.strictEqual(
+        resolveProfile("HMI-02KS").name,
+        "HMI-2000/HMI-02KS (route 4)",
+      );
+      assert.strictEqual(resolveProfile("HMI-1").name, "HMI (route 2)");
+      assert.strictEqual(resolveProfile("HMI-6").name, "HMI (route 0)");
+      // Substring matching: an id merely containing the token takes that route.
+      assert.strictEqual(
+        resolveProfile("HMI-3500").name,
+        "HMI-350/HMI-500 (route 1)",
+      );
+      assert.strictEqual(
+        resolveProfile("HMI-12000").name,
+        "HMI-2000/HMI-02KS (route 4)",
+      );
+      // Route 4 is tested before route 1, so a (hypothetical) id carrying both
+      // tokens resolves to route 4.
+      assert.strictEqual(
+        resolveProfile("HMI-2000-500").name,
+        "HMI-2000/HMI-02KS (route 4)",
+      );
+    });
+
+    test("sub-type entries beat their base prefix", () => {
+      assert.strictEqual(resolveProfile("HMD-V1").name, "HMD-V");
+      assert.strictEqual(resolveProfile("HMD-N1").name, "HMD-N");
+      assert.strictEqual(resolveProfile("HMD-1").name, "HMD");
+      assert.strictEqual(resolveProfile("HMHL-0").name, "HMHL (Mars SE)");
+      assert.strictEqual(resolveProfile("HMH-0").name, "HMH/SDH/VENX");
+      assert.strictEqual(resolveProfile("SDH-6K").name, "SDH-6K (V6000)");
+      assert.strictEqual(resolveProfile("SDH-0").name, "HMH/SDH/VENX");
+      assert.strictEqual(resolveProfile("VNSGPV-0").name, "VNSGPV");
+      assert.strictEqual(resolveProfile("VNSG-0").name, "VNSG/VNSEMINI/VNSB");
+      assert.strictEqual(resolveProfile("VNSE3US-0").name, "VNSE3US/VNSE3CH");
+      assert.strictEqual(resolveProfile("VNSE3-0").name, "VNS");
     });
 
     test("HME exact models beat the HME base entry", () => {
@@ -490,7 +626,8 @@ describe("device_matrix", () => {
     });
 
     test("TPM2 resolves to its own profile without colliding with TPM-CN", () => {
-      assert.strictEqual(resolveProfile("TPM2-0").name, "TPM2");
+      assert.strictEqual(resolveProfile("TPM2-0").name, "TPM2-0");
+      assert.strictEqual(resolveProfile("TPM2-1").name, "TPM2 (other)");
       assert.strictEqual(resolveProfile("TPM-CN").name, "TPM-CN");
     });
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -7,10 +7,43 @@ import {
   inverseForwardingPolicy,
   isAstraMeterFamily,
   isAstraMeterSyntheticMac,
+  parseVersion,
   resolveProfile,
 } from "./device_matrix.js";
 
 describe("device_matrix", () => {
+  describe("parseVersion", () => {
+    // main.ts converts the API's version string through this function, so a
+    // truncating parser here would silently strand HMD-N on the 2024 broker.
+    test("keeps the fractional part", () => {
+      assert.strictEqual(parseVersion("1.42"), 1.42);
+      assert.strictEqual(parseVersion("153.2"), 153.2);
+    });
+
+    test("an HMD-N reporting 1.42 reaches the 2025 broker", () => {
+      assert.strictEqual(
+        brokerForVersion("HMD-N1", parseVersion("1.42")),
+        "hame-2025",
+      );
+      assert.strictEqual(
+        brokerForVersion("HMD-N1", parseVersion("1.41")),
+        "hame-2024",
+      );
+    });
+
+    test("whole versions are unchanged", () => {
+      assert.strictEqual(parseVersion("226"), 226);
+      assert.strictEqual(parseVersion(226), 226);
+      assert.strictEqual(parseVersion(" 142 "), 142);
+    });
+
+    test("non-numeric strings fail closed", () => {
+      assert.ok(isNaN(parseVersion("1.4.3")));
+      assert.ok(isNaN(parseVersion("116foo")));
+      assert.ok(isNaN(parseVersion("")));
+    });
+  });
+
   describe("supportsVid (salt-based topic encryption threshold)", () => {
     describe("Jupiter devices (JPLS, HMM, HMN) - require firmware >= 136", () => {
       test("true for JPLS at 136, HMM at 140, HMN at 150", () => {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -81,7 +81,11 @@ export interface DeviceProfile {
    * does not match `shape` belongs to the second line and is not encrypted.
    */
   vidFirstLine?: { shape: RegExp; endsBefore: number };
-  /** Exact firmware versions that enable the remote topic id on the local broker. */
+  /**
+   * Exact firmware versions that enable the remote topic id on the local
+   * broker. Matched by equality, so a device reporting a fractional version
+   * (e.g. `226.5`) does not match the `226` entry.
+   */
   useRemoteTopicIdVersions?: number[];
   /** Inverse-forwarding policy for this family. */
   inverse: InversePolicy;
@@ -503,7 +507,13 @@ export function resolveProfile(type: string): DeviceProfile {
   );
 }
 
-function parseVersion(version: string | number): number {
+/**
+ * Parses a reported firmware version. Fractional versions are preserved: the
+ * HMD-N broker threshold is `1.42`, so truncating here would make it
+ * unreachable. Callers that turn an API string into a `Device.version` must go
+ * through this too, so the whole codebase agrees on what a version means.
+ */
+export function parseVersion(version: string | number): number {
   if (typeof version === "number") {
     return version;
   }

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -222,32 +222,65 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     // Marstek CT002 "new generation" (reported as TPM2-0, #201). Ships on the
     // 2025 broker and uses salt-based topic-id encryption on every firmware, so
-    // there is no pre-encryption threshold. Whole-family match (TPM2-*) so future
-    // generations are covered; TPM-CN starts with "TPM-" and is unaffected.
-    name: "TPM2",
-    matches: startsWith("TPM2"),
+    // there is no pre-encryption threshold. Only this exact id is recognized —
+    // see the TPM2 catch-all below. TPM-CN starts with "TPM-" and is unaffected.
+    name: "TPM2-0",
+    matches: exact("TPM2-0"),
     vidSupportVersion: 0,
     inverse: "auto",
   },
-
-  // --- HMI model-token rules (must precede the HMI base entry) ---
   {
-    // HMI-350 / HMI-500 ("route 1", #158 / #164): always stay on the 2024
-    // broker and never use topic encryption. Whole-token match so ids like
-    // "HMI-3500" / "HMI-5000" stay on the regular HMI path.
+    // Any other TPM2 id is unrecognized by the app: it stays on the 2024 broker
+    // and never uses topic encryption. Guessing the other way for a future
+    // TPM2-1 would be wrong on both axes at once.
+    name: "TPM2 (other)",
+    matches: startsWith("TPM2"),
+    brokerRoutes: ALWAYS_2024,
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+
+  // --- HMI routes ---
+  // The app classifies an HMI id by plain substring, not by whole token, and
+  // tests "2000"/"02KS" before "350"/"500". The four entries below reproduce
+  // that order (route 4 → 1 → 2 → 0); reordering them changes which route an id
+  // carrying more than one of those tokens lands on.
+  {
+    // Route 4. HMI-2000 (4-PV) and HMI-02KS use topic encryption from an
+    // earlier firmware than other HMI models.
+    name: "HMI-2000/HMI-02KS (route 4)",
+    matches: (t) =>
+      t.startsWith("HMI") && (t.includes("2000") || t.includes("02KS")),
+    brokerRoutes: migrate2024to2025(113),
+    vidSupportVersion: 105,
+    inverse: "auto",
+  },
+  {
+    // Route 1 (#158 / #164): always stays on the 2024 broker and never uses
+    // topic encryption. Substring match, so HMI-350S / HMI-500S are included.
     name: "HMI-350/HMI-500 (route 1)",
-    matches: (t) => t.startsWith("HMI") && /\b(350|500)\b/.test(t),
+    matches: (t) =>
+      t.startsWith("HMI") && (t.includes("350") || t.includes("500")),
     brokerRoutes: ALWAYS_2024,
     vidSupportVersion: Infinity,
     inverse: "auto",
   },
   {
-    // HMI-2000 (4-PV) uses topic encryption from an earlier firmware than other
-    // HMI models. Whole-token match so "HMI-12000" / "HMI-20001" don't match.
-    name: "HMI-2000",
-    matches: (t) => t.startsWith("HMI") && /\b2000\b/.test(t),
-    brokerRoutes: migrate2024to2025(113),
-    vidSupportVersion: 105,
+    // Route 2: any remaining HMI id containing a digit 1-5. Without an explicit
+    // brokerRoutes this would silently default to always-2025 and strand
+    // pre-129 devices on the wrong broker (#173).
+    name: "HMI (route 2)",
+    matches: (t) => t.startsWith("HMI") && /[1-5]/.test(t),
+    brokerRoutes: migrate2024to2025(129),
+    vidSupportVersion: 120,
+    inverse: "auto",
+  },
+  {
+    // Route 0: everything else, e.g. HMI-6. Behaves like route 1.
+    name: "HMI (route 0)",
+    matches: startsWith("HMI"),
+    brokerRoutes: ALWAYS_2024,
+    vidSupportVersion: Infinity,
     inverse: "auto",
   },
 
@@ -323,22 +356,31 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     vidFirstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
+  // HMD outdoor power stations. The app keys off the sub-type token after the
+  // first "-", so the three entries below match that token directly rather than
+  // a loose substring. No HMD supports vid (topic encryption) on any firmware —
+  // the app's CommonHelper.isSupportVid has no HMD branch and returns false.
   {
-    // HMD outdoor power stations. The "V" (V6000) and "N" (M5000) sub-types are
-    // always on the 2025 broker; any other HMD (e.g. HMD-1..7) migrates only
-    // above firmware 154. None of the HMD family supports vid (topic encryption)
-    // — the app's CommonHelper.isSupportVid has no HMD branch and returns false.
-    // Match the V/N sub-type token directly (HMD-V*/HMD-N*) rather than a loose
-    // substring, so other HMD ids that merely contain V/N elsewhere don't match.
-    name: "HMD-V/HMD-N",
-    matches: (t) => t.startsWith("HMD-V") || t.startsWith("HMD-N"),
+    name: "HMD-V",
+    matches: startsWith("HMD-V"),
+    // No brokerRoutes: always the 2025 broker.
     vidSupportVersion: Infinity,
     inverse: "auto",
   },
   {
+    name: "HMD-N",
+    matches: startsWith("HMD-N"),
+    brokerRoutes: migrate2024to2025(1.42),
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // HMD-1..7, HMD-41/61/71/72, bare HMD: never offered the 2025 broker. The
+    // former migration at firmware 155 sent these to the 2025 broker with the
+    // wrong credentials and topic prefix, so they exchanged no traffic (#214).
     name: "HMD",
     matches: startsWith("HMD"),
-    brokerRoutes: migrate2024to2025(155),
+    brokerRoutes: ALWAYS_2024,
     vidSupportVersion: Infinity,
     inverse: "auto",
   },
@@ -357,22 +399,83 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     astraMeter: true,
   },
   {
-    // Regular HMI inverters migrate from the 2024 broker to the 2025 broker at
-    // firmware 129. The HMI-350/HMI-500 (always 2024) and HMI-2000 (migrates at
-    // 113) exact entries above take precedence. Without an explicit brokerRoutes
-    // this would silently default to always-2025 and strand pre-129 devices on
-    // the wrong broker (#173).
-    name: "HMI",
-    matches: startsWith("HMI"),
-    brokerRoutes: migrate2024to2025(129),
-    vidSupportVersion: 120,
+    // Mars SE. Must precede the HMH entry below, which its id also starts with.
+    name: "HMHL (Mars SE)",
+    matches: startsWith("HMHL"),
+    vidSupportVersion: 0,
     inverse: "auto",
   },
   {
-    // Venus series (VNSD*/VNSA* incl. VNSD2/VNSA2, VNSE3*, VNSE4): always on the
-    // 2025 broker, at any firmware — the whole family runs on the 2025
-    // infrastructure and never used the 2024 broker. VAAC2/VDAC do not start with
-    // "VNS" and reach the default (also always-2025).
+    // V6000. Must precede the SDH entry below.
+    name: "SDH-6K (V6000)",
+    matches: startsWith("SDH-6K"),
+    vidSupportVersion: 0,
+    inverse: "auto",
+  },
+  {
+    // Mars (HMH), M5000 (SDH other than SDH-6K) and Venus X (VENX): on the 2025
+    // broker, but never topic encryption.
+    name: "HMH/SDH/VENX",
+    matches: startsWith("HMH", "SDH", "VENX"),
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // Marstek CT003 meter readers: SMR-0 (P1, NL), SMR-1 (IR, DE), SMR-2
+    // (TIC, FR).
+    name: "SMR (CT003)",
+    matches: startsWith("SMR-"),
+    vidSupportVersion: 0,
+    inverse: "auto",
+  },
+  {
+    // M5000 (HMC-1/2/7 and SCH-1), Mars-A (other HMC), HML and the Mars-family
+    // UB variant: 2024 broker and never topic encryption. Without this entry
+    // they reach DEFAULT_PROFILE, which is wrong on both axes, so they exchange
+    // no traffic at all.
+    name: "HMC/SCH/HML/UB",
+    matches: startsWith("HMC", "SCH", "HML", "UB"),
+    brokerRoutes: ALWAYS_2024,
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // These two use topic encryption unconditionally, not from 123 like the
+    // rest of the Venus family.
+    name: "VNSE3US/VNSE3CH",
+    matches: startsWith("VNSE3US", "VNSE3CH"),
+    vidSupportVersion: 0,
+    inverse: "auto",
+  },
+  {
+    // Venus G PV: on the 2024 broker and never topic encryption, unlike its
+    // VNSG sibling. Must precede VNSG, whose prefix would otherwise swallow it.
+    name: "VNSGPV",
+    matches: startsWith("VNSGPV"),
+    brokerRoutes: ALWAYS_2024,
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // VNS-prefixed but not Venus devices: 2025 broker, never topic encryption.
+    name: "VNSG/VNSEMINI/VNSB",
+    matches: startsWith("VNSG", "VNSEMINI", "VNSB"),
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // 2025 broker (like the default it used to reach), but never topic
+    // encryption.
+    name: "VAAC2",
+    matches: startsWith("VAAC2"),
+    vidSupportVersion: Infinity,
+    inverse: "auto",
+  },
+  {
+    // Venus series (VNSD*/VNSA* incl. VNSD2/VNSA2, VNSE3, VNSE3AU, VNSE4,
+    // VNSEMAX): always on the 2025 broker, at any firmware — the whole family
+    // runs on the 2025 infrastructure and never used the 2024 broker. VEPRO/VDAC
+    // do not start with "VNS" and reach the default (also always-2025).
     name: "VNS",
     matches: startsWith("VNS"),
     vidSupportVersion: 123,
@@ -431,9 +534,9 @@ export function supportsVid(
   const profile = resolveProfile(type);
   if (profile.vidRoutes) {
     // Only the raw string carries the shape the app keys off, so check it
-    // before falling back to the numeric steps. A number reaching here is
-    // already whole in practice (`main.ts` parses the API version with
-    // parseInt) and stringifies back to the same shape the app saw.
+    // before falling back to the numeric steps. A number reaching here keeps
+    // any fractional part the API reported (`main.ts` uses parseFloat) and so
+    // stringifies back to the same shape the app saw.
     const raw = String(version).trim();
     const firstLine = profile.vidFirstLine;
     if (

--- a/src/main.ts
+++ b/src/main.ts
@@ -171,7 +171,12 @@ async function start() {
             `Unknown device type from API: ${device.type}. Using as-is.`,
           );
         }
-        const v = parseInt(device.version, 10);
+        // parseFloat, not parseInt: some families report a dotted firmware
+        // ("1.42") whose fractional part decides both the broker and the
+        // topic-encryption behaviour. Truncating it here would make those
+        // thresholds unreachable. No-op for the whole versions everything else
+        // reports.
+        const v = parseFloat(device.version);
         return {
           device_id: device.devid,
           mac: device.mac,

--- a/src/main.ts
+++ b/src/main.ts
@@ -172,10 +172,23 @@ async function start() {
             `Unknown device type from API: ${device.type}. Using as-is.`,
           );
         }
-        // Shared with the device matrix so both agree on what a version means.
-        // Notably it keeps the fractional part: the HMD-N broker threshold is
-        // 1.42, which truncating parsers such as parseInt can never satisfy.
-        const v = parseVersion(device.version);
+        // parseVersion is shared with the device matrix so both agree on what a
+        // version means, and it keeps the fractional part: the HMD-N broker
+        // threshold is 1.42, which truncating parsers such as parseInt can
+        // never satisfy. Its strictness is deliberate there — it must not
+        // satisfy a threshold from a partial parse — but it is not the safe
+        // default here: reading a suffixed version like "116foo" as 1 would
+        // pick the wrong broker and strand the device, so fall back to its
+        // numeric prefix. Either way, say so rather than routing silently on a
+        // version we could not read exactly.
+        const exact = parseVersion(device.version);
+        const v = isNaN(exact) ? parseFloat(device.version) : exact;
+        if (isNaN(exact)) {
+          logger.warn(
+            `Could not read firmware version "${device.version}" for device ${device.devid} exactly; ` +
+              (isNaN(v) ? "assuming version 1" : `assuming version ${v}`),
+          );
+        }
         return {
           device_id: device.devid,
           mac: device.mac,

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ import {
   inverseForwardingPolicy,
   isAstraMeterFamily,
   isAstraMeterSyntheticMac,
+  parseVersion,
   supportsVid,
 } from "./device_matrix.js";
 import {
@@ -171,12 +172,10 @@ async function start() {
             `Unknown device type from API: ${device.type}. Using as-is.`,
           );
         }
-        // parseFloat, not parseInt: some families report a dotted firmware
-        // ("1.42") whose fractional part decides both the broker and the
-        // topic-encryption behaviour. Truncating it here would make those
-        // thresholds unreachable. No-op for the whole versions everything else
-        // reports.
-        const v = parseFloat(device.version);
+        // Shared with the device matrix so both agree on what a version means.
+        // Notably it keeps the fractional part: the HMD-N broker threshold is
+        // 1.42, which truncating parsers such as parseInt can never satisfy.
+        const v = parseVersion(device.version);
         return {
           device_id: device.devid,
           mac: device.mac,

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,34 +6,66 @@ export type DeviceGen = (typeof deviceGenerations)[number];
 export const deviceTypes = [
   "HMA",
   "HMB",
+  "HMC",
   "HMD",
   "HME",
   "HMF",
   "HMG",
+  "HMH",
+  "HMHL",
   "HMJ",
   "HMK",
   "HMI",
+  "HML",
   "HMM",
   "HMN",
+  "SCH",
+  "SMR",
   "TPM2",
-  "VNSE3",
+  "UB",
+  "VAAC2",
+  "VDAC",
+  "VENX",
+  "VEPRO",
   "VNSA",
+  "VNSA2",
+  "VNSACH",
+  "VNSB",
   "VNSD",
+  "VNSD2",
+  "VNSDCH",
+  "VNSE3",
+  "VNSE3AU",
+  "VNSE3CH",
+  "VNSE3US",
+  "VNSE4",
+  "VNSEMAX",
+  "VNSEMINI",
+  "VNSG",
+  "VNSGPV",
 ] as const;
 export type DeviceType = (typeof deviceTypes)[number];
+
+// Model-suffixed HMI identifiers (e.g. HMI-2000, the 4-PV microinverter) that
+// don't follow the generation numbering used above.
+export const hmiModelTypes = [
+  "HMI-2000",
+  "HMI-350",
+  "HMI-500",
+  "HMI-350S",
+  "HMI-500S",
+  "HMI-02KS",
+] as const;
+
+// Identifiers that carry no generation suffix at all.
+export const standaloneDeviceTypes = ["TPM-CN", "SDH-6K"] as const;
 
 export type DeviceTypeIdentifier =
   | `${DeviceType}-${DeviceGen}`
   | `JPLS-${number}H`
-  | `HMI-${number}`;
-
-// Model-suffixed HMI identifiers (e.g. HMI-2000, the 4-PV microinverter) that
-// don't follow the generation numbering used above.
-export const hmiModelTypes: DeviceTypeIdentifier[] = [
-  "HMI-2000",
-  "HMI-350",
-  "HMI-500",
-];
+  | `HMI-${number}`
+  | (typeof hmiModelTypes)[number]
+  | (typeof standaloneDeviceTypes)[number];
 
 export const knownDeviceTypes: DeviceTypeIdentifier[] = [
   ...(deviceGenerations.flatMap((gen) =>
@@ -43,6 +75,7 @@ export const knownDeviceTypes: DeviceTypeIdentifier[] = [
     (gen) => `JPLS-${gen}H` as const,
   ) as DeviceTypeIdentifier[]),
   ...hmiModelTypes,
+  ...standaloneDeviceTypes,
 ];
 
 export interface Device {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,6 @@
 export const deviceGenerations = [
-  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 25, 50,
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 25, 31, 41, 50, 51,
+  61, 71, 72,
 ] as const;
 export type DeviceGen = (typeof deviceGenerations)[number];
 
@@ -20,6 +21,7 @@ export const deviceTypes = [
   "HMM",
   "HMN",
   "SCH",
+  "SDH",
   "SMR",
   "TPM2",
   "UB",
@@ -58,10 +60,14 @@ export const hmiModelTypes = [
 ] as const;
 
 // Identifiers that carry no generation suffix at all.
-export const standaloneDeviceTypes = ["TPM-CN", "SDH-6K"] as const;
+export const standaloneDeviceTypes = ["TPM-CN"] as const;
 
 export type DeviceTypeIdentifier =
   | `${DeviceType}-${DeviceGen}`
+  // HMD-V*/HMD-N* are sub-types with their own profiles, and SDH ids carry a
+  // "K" suffix (SDH-6K); neither fits the plain `${type}-${gen}` shape.
+  | `HMD-${"V" | "N"}${DeviceGen}`
+  | `SDH-${DeviceGen}K`
   | `JPLS-${number}H`
   | `HMI-${number}`
   | (typeof hmiModelTypes)[number]
@@ -71,6 +77,11 @@ export const knownDeviceTypes: DeviceTypeIdentifier[] = [
   ...(deviceGenerations.flatMap((gen) =>
     deviceTypes.map((type) => `${type}-${gen}` as const),
   ) as DeviceTypeIdentifier[]),
+  ...(deviceGenerations.flatMap((gen) => [
+    `HMD-V${gen}` as const,
+    `HMD-N${gen}` as const,
+    `SDH-${gen}K` as const,
+  ]) as DeviceTypeIdentifier[]),
   ...(deviceGenerations.map(
     (gen) => `JPLS-${gen}H` as const,
   ) as DeviceTypeIdentifier[]),


### PR DESCRIPTION
## Summary

This PR significantly expands device type support and corrects broker routing for several device families. It refines the device matrix to accurately reflect which devices support topic encryption and which broker they should use, based on firmware version and device type.

## Key Changes

- **TPM2 handling**: Changed from whole-family match (`TPM2-*`) to exact match (`TPM2-0` only). Other TPM2 ids are now treated as unrecognized devices that stay on the 2024 broker and never use topic encryption.

- **HMI routing refactored**: Reorganized HMI device matching into four distinct routes (0, 1, 2, 4) with proper precedence:
  - Route 4 (HMI-2000/HMI-02KS): Migrate to 2025 broker at firmware 113, support vid from 105
  - Route 1 (HMI-350/HMI-500 and variants): Always 2024 broker, never topic encryption
  - Route 2 (regular HMI): Migrate to 2025 broker at firmware 129, support vid from 120
  - Route 0 (other HMI like HMI-6): Always 2024 broker, never topic encryption
  - Added support for HMI-350S, HMI-500S, and HMI-02KS variants

- **HMD family corrections**:
  - HMD-V: Always 2025 broker (no migration threshold)
  - HMD-N: Migrates to 2025 broker at firmware 1.42 (not 155)
  - HMD (other): Reverted to always 2024 broker (removed incorrect 155 migration threshold that caused traffic failures)

- **New device families added**:
  - SMR (CT003 meter readers): Always support topic encryption from firmware 0
  - HMC/SCH/HML/UB: 2024 broker, never topic encryption
  - HMHL (Mars SE): 2025 broker, supports vid from firmware 0
  - SDH-6K (V6000): 2025 broker, supports vid from firmware 0
  - HMH/SDH/VENX: 2025 broker, never topic encryption
  - VNSE3US/VNSE3CH: Unconditional topic encryption (not from firmware 123)
  - VNSGPV: 2024 broker, never topic encryption (unlike VNSG)
  - VNSG/VNSEMINI/VNSB: 2025 broker, never topic encryption
  - VAAC2: 2025 broker, never topic encryption

- **Firmware version parsing**: Changed from `parseInt` to `parseFloat` in main.ts to properly handle dotted firmware versions (e.g., "1.42") where the fractional part affects broker and encryption behavior.

- **Device type registry**: Expanded `deviceTypes` array and added `standaloneDeviceTypes` for devices without generation suffixes (TPM-CN, SDH-6K).

## Notable Implementation Details

- HMI routing uses substring matching (not whole-token matching) to determine which route an id takes, with explicit precedence order (4 → 1 → 2 → 0)
- Device profile matching is now most-specific first, with sub-type entries (e.g., HMD-V, HMD-N) taking precedence over their base prefix
- Comprehensive test coverage added for all new device families and routing scenarios
- Documentation updated to reflect all device families and their broker/encryption behavior

https://claude.ai/code/session_014XPAcB72sPg9f1NBe6DFsT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for additional HMD, HMI, Marstek M5000, HML, UB, Venus G PV, SMR, TPM, and related device variants.
  - Improved device routing and encryption handling across supported models.
  - Added support for firmware versions containing decimal values.

- **Bug Fixes**
  - Fixed control requests failing on several older device firmware versions.
  - Prevented HMD outdoor power stations from losing traffic after firmware updates.
  - Corrected inverter device classification.
  - Removed an incorrect “Unknown device type” startup warning.

- **Documentation**
  - Updated the device support matrix and classification guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->