### PR TITLE
Support HMI second firmware line below version 100

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Added support for several device types that could not be forwarded at all: Marstek M5000 (HMC, SCH), HML, UB and Venus G PV (#214)
 - Fixed Mars (HMH), M5000 (SDH), Venus X, Venus G, Venus E Mini, VNSB and VAAC2 devices not responding to control requests, and the same on the US and CH variants of Venus 3 on older firmware (#214)
 - Fixed devices whose firmware version contains a decimal point being handled as if they were on a much older firmware (#214)
+- Fixed Marstek HMI inverters (e.g. Saturn M800, MI2000W) on a two-digit firmware version exchanging no data at all in either direction (#218)
 - Removed the spurious "Unknown device type" warning on startup for many supported devices (#214)
 - Updated the bundled runtime and add-on base image to currently supported versions. No change in behavior (#197)
 

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -54,10 +54,10 @@ switches to encrypted topic ids, and how forwarding is configured.
 | TPM2-0              | hame-2025                   | 0     | —               | auto        | CT002 new generation (#201) |
 | TPM2 (other)        | hame-2024                   | never | —               | auto        | unrecognised; only `TPM2-0` ships today |
 | SMR-0, SMR-1, SMR-2 | hame-2025                   | 0     | —               | auto        | CT003 meter readers: P1 (NL) / IR (DE) / TIC (FR) |
-| HMI-2000, HMI-02KS (3-digit fw) | hame-2024 → hame-2025 @113  | 105   | —               | auto        | "route 4"; 4-PV microinverter; see "HMI firmware lines" |
+| HMI-2000, HMI-02KS (fw ≥100)    | hame-2024 → hame-2025 @113  | 105   | —               | auto        | "route 4"; 4-PV microinverter; see "HMI firmware lines" |
 | HMI-2000, HMI-02KS (fw <100)    | hame-2025                   | 0     | —               | auto        | second firmware line |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", incl. `HMI-350S` / `HMI-500S`; see #158 / #164 |
-| HMI (regular, 3-digit fw) | hame-2024 → hame-2025 @129  | 120   | —               | auto        | "route 2": any remaining HMI id containing a digit 1-5 |
+| HMI (regular, fw ≥100)    | hame-2024 → hame-2025 @129  | 120   | —               | auto        | "route 2": any remaining HMI id containing a digit 1-5 |
 | HMI (regular, fw <100)    | hame-2025                   | 0     | —               | auto        | second firmware line |
 | HMI (other)         | hame-2024                   | never | —               | auto        | "route 0", e.g. `HMI-6` |
 | HMC, SCH, HML, UB   | hame-2024                   | never | —               | auto        | M5000 (`HMC-1/2/7`, `SCH-1`), Mars-A (other HMC) |

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -54,9 +54,11 @@ switches to encrypted topic ids, and how forwarding is configured.
 | TPM2-0              | hame-2025                   | 0     | —               | auto        | CT002 new generation (#201) |
 | TPM2 (other)        | hame-2024                   | never | —               | auto        | unrecognised; only `TPM2-0` ships today |
 | SMR-0, SMR-1, SMR-2 | hame-2025                   | 0     | —               | auto        | CT003 meter readers: P1 (NL) / IR (DE) / TIC (FR) |
-| HMI-2000, HMI-02KS  | hame-2024 → hame-2025 @113  | 105   | —               | auto        | "route 4"; 4-PV microinverter |
+| HMI-2000, HMI-02KS (3-digit fw) | hame-2024 → hame-2025 @113  | 105   | —               | auto        | "route 4"; 4-PV microinverter; see "HMI firmware lines" |
+| HMI-2000, HMI-02KS (fw <100)    | hame-2025                   | 0     | —               | auto        | second firmware line |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", incl. `HMI-350S` / `HMI-500S`; see #158 / #164 |
-| HMI (regular)       | hame-2024 → hame-2025 @129  | 120   | —               | auto        | "route 2": any remaining HMI id containing a digit 1-5 |
+| HMI (regular, 3-digit fw) | hame-2024 → hame-2025 @129  | 120   | —               | auto        | "route 2": any remaining HMI id containing a digit 1-5 |
+| HMI (regular, fw <100)    | hame-2025                   | 0     | —               | auto        | second firmware line |
 | HMI (other)         | hame-2024                   | never | —               | auto        | "route 0", e.g. `HMI-6` |
 | HMC, SCH, HML, UB   | hame-2024                   | never | —               | auto        | M5000 (`HMC-1/2/7`, `SCH-1`), Mars-A (other HMC) |
 | HMHL                | hame-2025                   | 0     | —               | auto        | Mars SE |
@@ -78,6 +80,16 @@ firmware is not simply "newer" than a 1xx one: the line starts over on the 2024
 broker with plaintext topic ids and migrates again at its own thresholds. So a
 JPLS on fw 231 is on the 2024 broker without topic encryption, while the same
 family on fw 136 is already on the 2025 broker with encrypted topic ids.
+
+## HMI firmware lines
+
+The HMI inverters on routes 2 and 4 have the same split, keyed on the numeric
+version rather than its shape: `InvertVersionController` compares the parsed
+version against 100 *before* the route's own threshold, and anything below it
+takes the supported branch on both axes. So an HMI-2000 on fw 50 is on the 2025
+broker with encrypted topic ids, while the same inverter on fw 100 is back on
+the 2024 broker with plaintext ones until it reaches 113 (129 for route 2).
+Routes 0 and 1 return false unconditionally and have no second line.
 
 ## HME firmware lines
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -240,6 +240,21 @@ describe("device_matrix", () => {
         assert.strictEqual(supportsVid("HMI-6", "120.0"), false);
         assert.strictEqual(supportsVid("HMI-6", "999.0"), false);
       });
+      // Routes 2 and 4 test the version against 100 before their own
+      // threshold, and anything below it takes the supported branch: a
+      // two-digit HMI firmware is on the second line, which already encrypts.
+      test("second firmware line (below 100) always encrypts", () => {
+        for (const type of ["HMI-2000", "HMI-02KS", "HMI-1"]) {
+          assert.strictEqual(supportsVid(type, "50"), true, type);
+          assert.strictEqual(supportsVid(type, "99.9"), true, type);
+          assert.strictEqual(supportsVid(type, "100"), false, type);
+        }
+      });
+      test("routes 0 and 1 have no second line", () => {
+        for (const type of ["HMI-350", "HMI-500S", "HMI-6"]) {
+          assert.strictEqual(supportsVid(type, "50"), false, type);
+        }
+      });
       // The app classifies by substring, so an id merely containing 350/500 or
       // 2000 takes that route rather than the regular HMI one.
       test("substring matching decides the route", () => {
@@ -447,6 +462,21 @@ describe("device_matrix", () => {
       for (const type of ["HMI-2000", "HMI-02KS", "HMI-12000"]) {
         assert.strictEqual(brokerForVersion(type, 112), "hame-2024", type);
         assert.strictEqual(brokerForVersion(type, 113), "hame-2025", type);
+      }
+    });
+
+    test("HMI second firmware line (below 100) is on hame-2025", () => {
+      for (const type of ["HMI-2000", "HMI-02KS", "HMI-1"]) {
+        assert.strictEqual(brokerForVersion(type, 50), "hame-2025", type);
+        assert.strictEqual(brokerForVersion(type, 99), "hame-2025", type);
+        // The main line starts over on the 2024 broker.
+        assert.strictEqual(brokerForVersion(type, 100), "hame-2024", type);
+      }
+    });
+
+    test("routes 0 and 1 stay on hame-2024 below 100 too", () => {
+      for (const type of ["HMI-350", "HMI-500S", "HMI-6"]) {
+        assert.strictEqual(brokerForVersion(type, 50), "hame-2024", type);
       }
     });
 

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -179,6 +179,39 @@ function hmeVidRoutes(secondLineVid: number, mainLineVid: number): VidRoute[] {
   ];
 }
 
+/**
+ * Where the HMI inverters' main firmware line starts. `InvertVersionController`
+ * tests the parsed version against 100 *before* the per-route threshold, and
+ * anything below it takes the "supported" branch on both axes — so a two-digit
+ * HMI firmware is on the 2025 broker with encrypted topic ids, exactly like the
+ * Jupiter and HME second lines. The comparison is numeric (`double.parse`), so
+ * no {@link DeviceProfile.vidFirstLine} shape rule is needed here.
+ */
+const HMI_MAIN_LINE_START = 100;
+
+/**
+ * Broker routing for an HMI inverter across both of its firmware lines. Below
+ * {@link HMI_MAIN_LINE_START} the device is on the second line and already on
+ * the 2025 broker; the main line starts over on the 2024 broker and migrates
+ * again at `mainLineMigration`.
+ */
+function hmiBrokerRoutes(mainLineMigration: number): BrokerRoute[] {
+  return [
+    { since: 0, broker: BROKER_2025 },
+    { since: HMI_MAIN_LINE_START, broker: BROKER_2024 },
+    { since: mainLineMigration, broker: BROKER_2025 },
+  ];
+}
+
+/** Salt-based (`cq`) topic-id encryption across both HMI firmware lines. */
+function hmiVidRoutes(mainLineVid: number): VidRoute[] {
+  return [
+    { since: 0, supported: true },
+    { since: HMI_MAIN_LINE_START, supported: false },
+    { since: mainLineVid, supported: true },
+  ];
+}
+
 /** Trim + uppercase so base-type handling is done exactly one way everywhere. */
 export function normalizeType(type: string): string {
   return type.trim().toUpperCase();
@@ -251,12 +284,13 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   // carrying more than one of those tokens lands on.
   {
     // Route 4. HMI-2000 (4-PV) and HMI-02KS use topic encryption from an
-    // earlier firmware than other HMI models.
+    // earlier firmware than other HMI models. Both axes also have a second
+    // firmware line below 100 — see hmiBrokerRoutes.
     name: "HMI-2000/HMI-02KS (route 4)",
     matches: (t) =>
       t.startsWith("HMI") && (t.includes("2000") || t.includes("02KS")),
-    brokerRoutes: migrate2024to2025(113),
-    vidSupportVersion: 105,
+    brokerRoutes: hmiBrokerRoutes(113),
+    vidRoutes: hmiVidRoutes(105),
     inverse: "auto",
   },
   {
@@ -272,11 +306,12 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   {
     // Route 2: any remaining HMI id containing a digit 1-5. Without an explicit
     // brokerRoutes this would silently default to always-2025 and strand
-    // pre-129 devices on the wrong broker (#173).
+    // main-line devices below 129 on the wrong broker (#173). Same second
+    // firmware line below 100 as route 4.
     name: "HMI (route 2)",
     matches: (t) => t.startsWith("HMI") && /[1-5]/u.test(t),
-    brokerRoutes: migrate2024to2025(129),
-    vidSupportVersion: 120,
+    brokerRoutes: hmiBrokerRoutes(129),
+    vidRoutes: hmiVidRoutes(120),
     inverse: "auto",
   },
   {


### PR DESCRIPTION
## Summary
This PR adds support for HMI inverters (routes 2 and 4) that have a second firmware line with versions below 100. These devices operate on different brokers and encryption settings than their main firmware line counterparts.

## Key Changes
- Added `HMI_MAIN_LINE_START` constant (100) to mark where HMI main firmware line begins
- Introduced `hmiBrokerRoutes()` function to handle broker routing across both HMI firmware lines:
  - Versions 0-99: hame-2025 broker (second line, encrypted)
  - Versions 100+: hame-2024 broker (main line, plaintext until migration threshold)
  - Migration thresholds: 113 for route 4, 129 for route 2
- Introduced `hmiVidRoutes()` function to handle topic-id encryption across both firmware lines:
  - Versions 0-99: encryption supported (second line)
  - Versions 100+: encryption not supported until main line threshold
- Updated device profiles for HMI-2000/HMI-02KS (route 4) and HMI regular (route 2) to use new routing functions instead of `migrate2024to2025()` and `vidSupportVersion`
- Routes 0 and 1 (HMI-350, HMI-500, HMI-6) remain unchanged with no second line support

## Implementation Details
- The version comparison is numeric (via `double.parse`), so no shape validation is needed
- The second firmware line behavior mirrors the Jupiter and HME implementations already in the codebase
- Added comprehensive test coverage for both broker routing and VID support across firmware lines
- Updated documentation to clarify the two-line split for affected HMI routes

https://claude.ai/code/session_01KKYxhXL71XnKAzpG6YYCuJ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed communication with Marstek HMI inverters using two-digit firmware versions (including Saturn M800 and MI2000W), restoring data exchange.
  * Improved HMI firmware-line handling to ensure correct broker routing and topic encryption across firmware ranges.

* **Documentation**
  * Updated the device support matrix with clearer HMI firmware-specific routing/encryption guidance, including the “second firmware line” behavior and thresholds.

* **Tests**
  * Expanded coverage to validate HMI broker routing and topic-encryption behavior for both firmware-line scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->