### PR TITLE
Fix TPM-CN firmware line handling for topic encryption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [Next]
 - Fixed Marstek `TPM-CN` meters on a two-digit firmware version exchanging no data in either direction, because the relay addressed them under the wrong id. Like the HME meters, TPM-CN ships two firmware lines and the second one needs different handling (#234)
+- Fixed HME and TPM-CN meters whose firmware version contains a decimal point being treated as if they were on the other firmware line, which put them on the wrong cloud connection and addressed them under the wrong id (#234)
 - Fixed the cloud connection being dropped immediately, so no data was exchanged at all, when the account has more than 8 devices. Accounts with a large number of devices now forward as many as the cloud accepts and log which devices were left out, instead of failing entirely (#232)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 ## [Next]
-- Fixed Marstek `TPM-CN` meters on a two-digit firmware version exchanging no data in either direction, because the relay addressed them under the wrong id. Like the HME meters, TPM-CN ships two firmware lines and the second one needs different handling
+- Fixed Marstek `TPM-CN` meters on a two-digit firmware version exchanging no data in either direction, because the relay addressed them under the wrong id. Like the HME meters, TPM-CN ships two firmware lines and the second one needs different handling (#234)
 - Fixed the cloud connection being dropped immediately, so no data was exchanged at all, when the account has more than 8 devices. Accounts with a large number of devices now forward as many as the cloud accepts and log which devices were left out, instead of failing entirely (#232)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- Fixed Marstek `TPM-CN` meters on a two-digit firmware version exchanging no data in either direction, because the relay addressed them under the wrong id. Like the HME meters, TPM-CN ships two firmware lines and the second one needs different handling
 - Fixed the cloud connection being dropped immediately, so no data was exchanged at all, when the account has more than 8 devices. Accounts with a large number of devices now forward as many as the cloud accepts and log which devices were left out, instead of failing entirely (#232)
 
 

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -46,11 +46,12 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMD-N               | hame-2024 → hame-2025 @1.42 | never | —               | auto        | outdoor power station |
 | HMD (other)         | hame-2024                   | never | —               | auto        | `HMD-1`…`HMD-7`, `HMD-41/61/71/72`, bare `HMD`; never offered the 2025 broker |
 | HME (base / other)  | hame-2024                   | never | —               | auto        | AstraMeter family; non-2/3/4/5 |
-| HME-2, HME-4 (3-digit fw) | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family; see "HME firmware lines" |
+| HME-2, HME-4 (3-digit fw) | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family; see "CT firmware lines" |
 | HME-2, HME-4 (other fw)   | hame-2024 → hame-2025 @24   | 25    | —               | auto        | |
 | HME-3, HME-5 (3-digit fw) | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
 | HME-3, HME-5 (other fw)   | hame-2024 → hame-2025 @33   | 34    | —               | auto        | |
-| TPM-CN              | hame-2025                   | 101   | —               | auto        | standalone identifier |
+| TPM-CN (3-digit fw) | hame-2025                   | 101   | —               | auto        | standalone identifier; see "CT firmware lines" |
+| TPM-CN (other fw)   | hame-2025                   | 0     | —               | auto        | |
 | TPM2-0              | hame-2025                   | 0     | —               | auto        | CT002 new generation (#201) |
 | TPM2 (other)        | hame-2024                   | never | —               | auto        | unrecognised; only `TPM2-0` ships today |
 | SMR-0, SMR-1, SMR-2 | hame-2025                   | 0     | —               | auto        | CT003 meter readers: P1 (NL) / IR (DE) / TIC (FR) |
@@ -70,7 +71,7 @@ switches to encrypted topic ids, and how forwarding is configured.
 | VNSGPV              | hame-2024                   | never | —               | auto        | Venus G PV; unlike its VNSG sibling |
 | VNSG, VNSEMINI, VNSB | hame-2025                  | never | —               | auto        | VNS-prefixed but not Venus devices |
 | VAAC2               | hame-2025                   | never | —               | auto        | |
-| _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device; incl. `VEPRO`, `VDAC` |
+| _unknown_           | hame-2025                   | 0     | —               | auto        | assume a 2025-broker device; incl. `VEPRO`, `VDAC` — but see "Unverified rows" |
 
 ## Jupiter firmware lines
 
@@ -91,15 +92,44 @@ broker with encrypted topic ids, while the same inverter on fw 100 is back on
 the 2024 broker with plaintext ones until it reaches 113 (129 for route 2).
 Routes 0 and 1 return false unconditionally and have no second line.
 
-## HME firmware lines
+## CT firmware lines
 
-The HME meters (HME-2/HME-4 and HME-3/HME-5) have the same two-line split. The
+The CT meters (HME-2/HME-4, HME-3/HME-5 and TPM-CN) share a two-line split. The
 line is picked from the *length* of the firmware version string: a three-digit
 version (`116`, `119`) is on the main line, any other length (a two-digit
 version such as `50`, or a four-digit one) is on the second line, which reached
 the 2025 broker and encrypted topic ids at much lower versions. So an HME-2 on
 fw 50 is on the 2025 broker with encrypted topic ids, while the same meter on
-fw 100 is back on the 2024 broker with plaintext ones (#212).
+fw 100 is back on the 2024 broker with plaintext ones (#212). TPM-CN is on the
+2025 broker either way, but the same split governs its topic ids: off the main
+line it encrypts at any firmware rather than from fw 101.
+
+Only whole versions are modelled. The table compares numbers, which reproduces
+the app's length rule exactly for whole firmware versions; a fractional version
+inside 100-999 would be on the second line for the app and on the main line
+here. CT firmware is reported whole.
+
+## Unverified rows
+
+Every other row here has been checked against the app's own code. Two groups
+have not:
+
+- **The Venus broker column.** HMG, the VNS models, VAAC2, VEPRO and VDAC pick
+  their broker through a per-device object the app builds at run time, behind a
+  dispatch that neither running the app's code nor reading it resolves. Their
+  topic-id thresholds are confirmed; the broker column is unverified rather than
+  contradicted. All of them sit on `hame-2025` at every firmware except HMG,
+  whose migration at fw 153 is the one value in this group a device could
+  disagree with.
+- **`VEPRO` and `VDAC`.** The app groups both with the Venus family, while this
+  table leaves them to the unknown default. The two agree on the broker and
+  differ on topic ids: the default encrypts at any firmware, the Venus rule from
+  fw 123. Neither has been observed on a real device, so the default stands
+  until one is.
+
+The `inverse` column and the AstraMeter placeholder-MAC rule are Hame Relay's
+own handling rather than app behaviour, and cannot be confirmed from the app at
+all.
 
 ## Matching precedence
 

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -114,8 +114,8 @@ shape implies rather than the one the app would pick.
 
 ## Unverified rows
 
-Every other row here has been checked against the app's own code. Two groups
-have not:
+The broker and topic-id columns of every other row have been checked against the
+app's own code. Two groups have not:
 
 - **The Venus broker column.** HMG, the VNS models, VAAC2, VEPRO and VDAC pick
   their broker through a per-device object the app builds at run time, behind a

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -104,10 +104,13 @@ fw 100 is back on the 2024 broker with plaintext ones (#212). TPM-CN is on the
 2025 broker either way, but the same split governs its topic ids: off the main
 line it encrypts at any firmware rather than from fw 101.
 
-Only whole versions are modelled. The table compares numbers, which reproduces
-the app's length rule exactly for whole firmware versions; a fractional version
-inside 100-999 would be on the second line for the app and on the main line
-here. CT firmware is reported whole.
+The table's numbers reproduce that length rule exactly for whole firmware
+versions, and the shape of the reported version settles the rest: a version like
+`116.5` reads as main-line by value but is five characters, so it is second-line
+firmware and takes the second line's thresholds on both columns. Zeros at either
+end are the one gap: the version reaches the table as a number, so `116.0`
+arrives as `116` and `050` as `50`, and each is placed on the line its shortened
+shape implies rather than the one the app would pick.
 
 ## Unverified rows
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -132,12 +132,11 @@ describe("device_matrix", () => {
 
     describe("TPM-CN - two firmware lines, like the HME meters", () => {
       test("true at/above 101 on the main line", () => {
-        assert.strictEqual(supportsVid("TPM-CN", "101.0"), true);
-        assert.strictEqual(supportsVid("TPM-CN", "130.0"), true);
+        assert.strictEqual(supportsVid("TPM-CN", "101"), true);
+        assert.strictEqual(supportsVid("TPM-CN", "130"), true);
       });
       test("false below 101 on the main line", () => {
         assert.strictEqual(supportsVid("TPM-CN", "100"), false);
-        assert.strictEqual(supportsVid("TPM-CN", "100.9"), false);
       });
       // The app splits the CT family by the length of the version string and
       // encrypts unconditionally off the main line, so a two-digit TPM-CN is
@@ -148,6 +147,47 @@ describe("device_matrix", () => {
       });
       test("true again above the main line", () => {
         assert.strictEqual(supportsVid("TPM-CN", "1000"), true);
+      });
+    });
+
+    // The app counts characters rather than comparing numbers, so a version
+    // that reads as main-line but is not shaped like one is second-line
+    // firmware, which encrypts from far lower.
+    describe("CT meters - a version's shape picks its line, not its value", () => {
+      test("a fractional version inside 100-999 is on the second line", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "100.9"), true);
+        assert.strictEqual(supportsVid("HME-2", "116.5"), true);
+        assert.strictEqual(supportsVid("HME-3", "115.5"), true);
+      });
+      test("the same versions whole stay on the main line", () => {
+        assert.strictEqual(supportsVid("HME-2", "116"), false);
+        assert.strictEqual(supportsVid("HME-3", "115"), false);
+      });
+      test("a four-character version is second line too", () => {
+        assert.strictEqual(supportsVid("HME-2", "1000"), true);
+      });
+      test("below the second line's own threshold it is still false", () => {
+        assert.strictEqual(supportsVid("HME-2", "24.5"), false);
+        assert.strictEqual(supportsVid("HME-3", "33.5"), false);
+      });
+      // The app reads the line once and both answers follow from it, so the
+      // broker moves with the topic ids rather than staying behind on the
+      // main line's own threshold.
+      test("the broker follows the same line", () => {
+        assert.strictEqual(brokerForVersion("HME-2", "116.5"), "hame-2025");
+        assert.strictEqual(brokerForVersion("HME-2", "116"), "hame-2024");
+        assert.strictEqual(brokerForVersion("HME-3", "115.5"), "hame-2025");
+        assert.strictEqual(brokerForVersion("HME-3", "115"), "hame-2024");
+      });
+      test("a number reaching the broker keeps its shape", () => {
+        assert.strictEqual(
+          brokerForVersion("HME-2", parseVersion("116.5")),
+          "hame-2025",
+        );
+        assert.strictEqual(
+          brokerForVersion("HME-2", parseVersion("116")),
+          "hame-2024",
+        );
       });
     });
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -179,6 +179,14 @@ describe("device_matrix", () => {
         assert.strictEqual(brokerForVersion("HME-3", "115.5"), "hame-2025");
         assert.strictEqual(brokerForVersion("HME-3", "115"), "hame-2024");
       });
+      // A trailing ".0" is the shape a number cannot carry, which is why the
+      // relay hands the matrix the string the API reported.
+      test("a trailing zero only survives as text", () => {
+        assert.strictEqual(supportsVid("HME-2", "116.0"), true);
+        assert.strictEqual(supportsVid("HME-2", 116), false);
+        assert.strictEqual(brokerForVersion("HME-2", "116.0"), "hame-2025");
+        assert.strictEqual(brokerForVersion("HME-2", 116), "hame-2024");
+      });
       test("a number reaching the broker keeps its shape", () => {
         assert.strictEqual(
           brokerForVersion("HME-2", parseVersion("116.5")),

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -130,13 +130,24 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("TPM-CN - require firmware >= 101.0", () => {
-      test("true at/above 101", () => {
+    describe("TPM-CN - two firmware lines, like the HME meters", () => {
+      test("true at/above 101 on the main line", () => {
         assert.strictEqual(supportsVid("TPM-CN", "101.0"), true);
         assert.strictEqual(supportsVid("TPM-CN", "130.0"), true);
       });
-      test("false below 101", () => {
+      test("false below 101 on the main line", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "100"), false);
         assert.strictEqual(supportsVid("TPM-CN", "100.9"), false);
+      });
+      // The app splits the CT family by the length of the version string and
+      // encrypts unconditionally off the main line, so a two-digit TPM-CN is
+      // encrypted where the main line would still be plaintext.
+      test("true at any version on the second line", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "50"), true);
+        assert.strictEqual(supportsVid("TPM-CN", "1"), true);
+      });
+      test("true again above the main line", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "1000"), true);
       });
     });
 

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -82,6 +82,20 @@ export interface DeviceProfile {
    */
   vidFirstLine?: { shape: RegExp; endsBefore: number };
   /**
+   * The other shape rule, for families whose *off-line* firmware is not simply
+   * unencrypted (see the CT entries, where the second line reaches both the
+   * 2025 broker and encrypted topic ids from a much lower version than the main
+   * one). A raw version that does not match `shape` is answered from the steps
+   * below `startsAt` alone — the second line's own thresholds — instead of from
+   * the whole table.
+   *
+   * Unlike {@link vidFirstLine}, which only guards topic-id encryption, this
+   * governs {@link brokerRoutes} and {@link vidRoutes} alike, because the app
+   * reads the line once and both of its answers follow from it. Set this *or*
+   * {@link vidFirstLine}.
+   */
+  mainLine?: { shape: RegExp; startsAt: number };
+  /**
    * Exact firmware versions that enable the remote topic id on the local
    * broker. Matched by equality, so a device reporting a fractional version
    * (e.g. `226.5`) does not match the `226` entry.
@@ -145,11 +159,24 @@ const JUPITER_FIRST_LINE = { shape: /^1\d\d$/u, endsBefore: 200 };
  * as "50", or a four-digit one — is on the second line. The split covers the
  * whole CT family, TPM-CN included, not only the HME meters. For whole versions
  * it is exactly the range 100–999, so the numeric steps below reproduce the
- * app's choice; only a fractional version inside that range would need the
- * {@link DeviceProfile.vidFirstLine} treatment, and CT firmware is always
- * reported whole.
+ * app's choice on their own; {@link CT_MAIN_LINE} covers the versions where
+ * length and value disagree.
  */
 const CT_MAIN_LINE_START = 100;
+
+/**
+ * The shape half of that rule. `CtVersionController` counts characters, so a
+ * version is on the main line when it is exactly three of them — which for a
+ * whole version is the same as the range 100–999 the steps use, and for
+ * anything else is not: "116.5" sits inside that range but is five characters,
+ * so the app reads it as second-line firmware. Matching on the raw string
+ * keeps those with the line the app puts them on.
+ *
+ * A version that survives `parseVersion` reaches here with its shape intact,
+ * apart from trailing zeros and leading zeros ("116.0", "050"), which the
+ * number has already dropped.
+ */
+const CT_MAIN_LINE = { shape: /^.{3}$/u, startsAt: CT_MAIN_LINE_START };
 
 /**
  * Broker routing for an HME meter across both of its firmware lines (#212).
@@ -240,6 +267,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: exact("HME-2", "HME-4"),
     brokerRoutes: hmeBrokerRoutes(24, 119),
     vidRoutes: hmeVidRoutes(25, 122),
+    mainLine: CT_MAIN_LINE,
     inverse: "auto",
     astraMeter: true,
   },
@@ -248,6 +276,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: exact("HME-3", "HME-5"),
     brokerRoutes: hmeBrokerRoutes(33, 116),
     vidRoutes: hmeVidRoutes(34, 120),
+    mainLine: CT_MAIN_LINE,
     inverse: "auto",
     astraMeter: true,
   },
@@ -264,6 +293,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
       { since: CT_MAIN_LINE_START, supported: false },
       { since: 101, supported: true },
     ],
+    mainLine: CT_MAIN_LINE,
     inverse: "auto",
   },
   {
@@ -601,8 +631,9 @@ export function supportsVid(
     ) {
       return false;
     }
+    const routes = onLine(profile.vidRoutes, profile.mainLine, raw);
     let supported = false;
-    for (const route of profile.vidRoutes) {
+    for (const route of routes) {
       if (parsed >= route.since) {
         supported = route.supported;
       }
@@ -619,15 +650,40 @@ export function supportsVid(
  * given firmware. Replaces the `autoDetermineBroker` / `resolveBrokerMinVersion`
  * / `isLegacyOnlyDevice` logic.
  */
-export function brokerForVersion(type: string, version: number): string {
-  const routes = resolveProfile(type).brokerRoutes ?? DEFAULT_BROKER_ROUTES;
+export function brokerForVersion(
+  type: string,
+  version: string | number,
+): string {
+  const profile = resolveProfile(type);
+  const routes = onLine(
+    profile.brokerRoutes ?? DEFAULT_BROKER_ROUTES,
+    profile.mainLine,
+    version,
+  );
+  const parsed = parseVersion(version);
   let chosen = routes[0].broker;
   for (const route of routes) {
-    if (version >= route.since) {
+    if (parsed >= route.since) {
       chosen = route.broker;
     }
   }
   return chosen;
+}
+
+/**
+ * The steps that apply to a version's firmware line. Off the main line only the
+ * second line's own steps count, however high the version reads: the app picks
+ * the line first and never looks at the other one's thresholds.
+ */
+function onLine<T extends { since: number }>(
+  routes: T[],
+  mainLine: DeviceProfile["mainLine"],
+  version: string | number,
+): T[] {
+  if (!mainLine || mainLine.shape.test(String(version).trim())) {
+    return routes;
+  }
+  return routes.filter((route) => route.since < mainLine.startsAt);
 }
 
 /** Whether the remote topic id should be used on the local broker. */

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -139,16 +139,17 @@ const JUPITER_VID_ROUTES: VidRoute[] = [
 const JUPITER_FIRST_LINE = { shape: /^1\d\d$/u, endsBefore: 200 };
 
 /**
- * Where the HME meters' main firmware line starts. `CtVersionController` reads
- * the line off the *length* of the raw version string: a three-character
- * version ("116", "119") is on the main line, anything else — a two-digit
- * version such as "50", or a four-digit one — is on the second line. For whole
- * versions that is exactly the range 100–999, so the numeric steps below
- * reproduce the app's choice; only a fractional version inside that range
- * would need the {@link DeviceProfile.vidFirstLine} treatment, and HME
- * firmware is always reported whole.
+ * Where a CT meter's main firmware line starts. `CtVersionController` reads the
+ * line off the *length* of the raw version string: a three-character version
+ * ("116", "119") is on the main line, anything else — a two-digit version such
+ * as "50", or a four-digit one — is on the second line. The split covers the
+ * whole CT family, TPM-CN included, not only the HME meters. For whole versions
+ * it is exactly the range 100–999, so the numeric steps below reproduce the
+ * app's choice; only a fractional version inside that range would need the
+ * {@link DeviceProfile.vidFirstLine} treatment, and CT firmware is always
+ * reported whole.
  */
-const HME_MAIN_LINE_START = 100;
+const CT_MAIN_LINE_START = 100;
 
 /**
  * Broker routing for an HME meter across both of its firmware lines (#212).
@@ -165,7 +166,7 @@ function hmeBrokerRoutes(
   return [
     { since: 0, broker: BROKER_2024 },
     { since: secondLineMigration, broker: BROKER_2025 },
-    { since: HME_MAIN_LINE_START, broker: BROKER_2024 },
+    { since: CT_MAIN_LINE_START, broker: BROKER_2024 },
     { since: mainLineMigration, broker: BROKER_2025 },
   ];
 }
@@ -174,7 +175,7 @@ function hmeBrokerRoutes(
 function hmeVidRoutes(secondLineVid: number, mainLineVid: number): VidRoute[] {
   return [
     { since: secondLineVid, supported: true },
-    { since: HME_MAIN_LINE_START, supported: false },
+    { since: CT_MAIN_LINE_START, supported: false },
     { since: mainLineVid, supported: true },
   ];
 }
@@ -251,9 +252,18 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     astraMeter: true,
   },
   {
+    // TPM-CN runs the same two firmware lines as the HME meters, and the app
+    // reads the line the same way — off the length of the version string. Only
+    // the main line has a threshold: on the second line the app encrypts topic
+    // ids at any version, so a TPM-CN reporting "50" encrypts where a flat
+    // `vidSupportVersion: 101` would have sent plaintext.
     name: "TPM-CN",
     matches: exact("TPM-CN"),
-    vidSupportVersion: 101,
+    vidRoutes: [
+      { since: 0, supported: true },
+      { since: CT_MAIN_LINE_START, supported: false },
+      { since: 101, supported: true },
+    ],
     inverse: "auto",
   },
   {

--- a/src/main.ts
+++ b/src/main.ts
@@ -71,7 +71,7 @@ function autoDetermineBroker(device: Device): string | undefined {
   if (device.version == null) {
     return undefined;
   }
-  return brokerForVersion(device.type, device.version);
+  return brokerForVersion(device.type, device.version_text ?? device.version);
 }
 
 function cleanAndValidate(config: { devices: Device[] }): void {
@@ -203,6 +203,10 @@ async function start() {
           type: deviceType,
           name: device.name,
           version: isNaN(v) ? 1 : v,
+          // Only when it read as a version: an approximate one ("116foo" ->
+          // 116) is not the string the app saw, and handing it on would put
+          // the matrix back to guessing from a shape that was never reported.
+          version_text: isNaN(exact) ? undefined : device.version,
           salt: device.salt,
         } as Device;
       });
@@ -337,7 +341,7 @@ async function start() {
         } else if (
           device.salt &&
           device.version &&
-          supportsVid(device.type, device.version)
+          supportsVid(device.type, device.version_text ?? device.version)
         ) {
           logger.debug(
             `Device ${device.device_id} supports CommonHelper.cq method, using salt-based calculation`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -94,6 +94,13 @@ export interface Device {
   mac: string;
   type: DeviceTypeIdentifier;
   version?: number;
+  /**
+   * The firmware version exactly as the API reported it, kept only when it
+   * read as a version. Some families pick their firmware line off the *shape*
+   * of that string, which {@link version} no longer carries once "116.0" has
+   * become 116 — so the device matrix is given this where it exists.
+   */
+  version_text?: string;
   inverse_forwarding?: boolean;
   name?: string;
   broker_id?: string;


### PR DESCRIPTION
## Summary
TPM-CN meters now correctly handle their two-line firmware split, matching the behavior of HME meters. Previously, TPM-CN was treated as a single-line device with a fixed threshold at fw 101, which caused meters on two-digit firmware versions to fail data exchange.

## Changes
- **Device matrix documentation**: Renamed "HME firmware lines" section to "CT firmware lines" to reflect that HME-2/4, HME-3/5, and TPM-CN all share the same firmware line split logic
- **TPM-CN firmware handling**: Changed from a simple `vidSupportVersion: 101` to a `vidRoutes` array that models both firmware lines:
  - Second line (non-3-digit versions): supports topic encryption at any firmware version
  - Main line (3-digit versions like 100-999): requires fw 101+ for topic encryption
- **Test coverage**: Updated TPM-CN tests to verify both firmware lines work correctly, including the second-line behavior where two-digit versions encrypt unconditionally
- **Documentation**: Added "Unverified rows" section clarifying which device behaviors have been verified against the app's code and which remain unverified

## Implementation Details
The firmware line selection is determined by the length of the version string (3 characters = main line, anything else = second line). This matches how `CtVersionController` in the app reads the firmware version. The numeric comparison at 100 reproduces this length-based rule exactly for whole firmware versions.

https://claude.ai/code/session_01JyGifFLMsKeTZthwpg5yoD

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed incorrect firmware-line classification for Marstek TPM-CN and HME meters, including decimal and four-digit versions.
  - Corrected cloud connection, device identification, broker selection, and encrypted data handling for affected firmware versions.

- **Documentation**
  - Updated the device matrix with expanded firmware-line details, CT behavior guidance, and unverified device classifications.

- **Tests**
  - Added coverage for firmware thresholds, decimal versions, broker routing, encryption behavior, and version formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->