### PR TITLE
Fix firmware line detection for decimal versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [Next]
+- Fixed Marstek Jupiter devices (JPLS, HMM, HMN) whose firmware version contains a decimal point connecting to the wrong cloud service, so they exchanged no data at all. Such a version belongs to the second firmware line, which was already handled correctly for how these devices are addressed but not for where they connect
+- Fixed Marstek TPM-CN meters on a short firmware version containing a decimal point exchanging no data in either direction, because the relay addressed them under the wrong id
 - Fixed Marstek `TPM-CN` meters on a two-digit firmware version exchanging no data in either direction, because the relay addressed them under the wrong id. Like the HME meters, TPM-CN ships two firmware lines and the second one needs different handling (#234)
 - Fixed HME and TPM-CN meters whose firmware version contains a decimal point being treated as if they were on the other firmware line, which put them on the wrong cloud connection and addressed them under the wrong id (#234)
 - Fixed the cloud connection being dropped immediately, so no data was exchanged at all, when the account has more than 8 devices. Accounts with a large number of devices now forward as many as the cloud accepts and log which devices were left out, instead of failing entirely (#232)

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -36,21 +36,21 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMK                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
 | HMJ                 | hame-2024 → hame-2025 @108  | 116   | [108]           | selectable  | |
 | HMG                 | hame-2024 → hame-2025 @153  | 154   | —               | auto        | |
-| HMM (1xx firmware)  | hame-2024 → hame-2025 @135  | 136   | —               | auto        | see "Jupiter firmware lines" |
-| HMM (2xx firmware)  | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
-| HMN (1xx firmware)  | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
-| HMN (2xx firmware)  | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
-| JPLS (1xx firmware) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | `JPLS-NH` |
-| JPLS (2xx firmware) | hame-2024 → hame-2025 @232  | 236   | —               | auto        | e.g. Jupiter C Plus, #209 |
+| HMM (1xx-shaped fw) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | see "Jupiter firmware lines" |
+| HMM (other fw)      | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
+| HMN (1xx-shaped fw) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
+| HMN (other fw)      | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
+| JPLS (1xx-shaped fw)| hame-2024 → hame-2025 @135  | 136   | —               | auto        | `JPLS-NH` |
+| JPLS (other fw)     | hame-2024 → hame-2025 @232  | 236   | —               | auto        | e.g. Jupiter C Plus, #209 |
 | HMD-V               | hame-2025                   | never | —               | auto        | outdoor power station |
 | HMD-N               | hame-2024 → hame-2025 @1.42 | never | —               | auto        | outdoor power station |
 | HMD (other)         | hame-2024                   | never | —               | auto        | `HMD-1`…`HMD-7`, `HMD-41/61/71/72`, bare `HMD`; never offered the 2025 broker |
 | HME (base / other)  | hame-2024                   | never | —               | auto        | AstraMeter family; non-2/3/4/5 |
-| HME-2, HME-4 (3-digit fw) | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family; see "CT firmware lines" |
+| HME-2, HME-4 (3-char fw)  | hame-2024 → hame-2025 @119  | 122   | —               | auto        | AstraMeter family; see "CT firmware lines" |
 | HME-2, HME-4 (other fw)   | hame-2024 → hame-2025 @24   | 25    | —               | auto        | |
-| HME-3, HME-5 (3-digit fw) | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
+| HME-3, HME-5 (3-char fw)  | hame-2024 → hame-2025 @116  | 120   | —               | auto        | AstraMeter family |
 | HME-3, HME-5 (other fw)   | hame-2024 → hame-2025 @33   | 34    | —               | auto        | |
-| TPM-CN (3-digit fw) | hame-2025                   | 101   | —               | auto        | standalone identifier; see "CT firmware lines" |
+| TPM-CN (3-char fw)  | hame-2025                   | 101   | —               | auto        | standalone identifier; see "CT firmware lines" |
 | TPM-CN (other fw)   | hame-2025                   | 0     | —               | auto        | |
 | TPM2-0              | hame-2025                   | 0     | —               | auto        | CT002 new generation (#201) |
 | TPM2 (other)        | hame-2024                   | never | —               | auto        | unrecognised; only `TPM2-0` ships today |
@@ -82,6 +82,15 @@ broker with plaintext topic ids and migrates again at its own thresholds. So a
 JPLS on fw 231 is on the 2024 broker without topic encryption, while the same
 family on fw 136 is already on the 2025 broker with encrypted topic ids.
 
+The line comes from the *shape* of the reported version, not its value:
+`JupiterVersionController.isRelease()` puts a device on the 1xx line only when
+the raw firmware string is exactly three digits starting with `1`. The app reads
+that once and answers both columns from it, so a version like `150.5` is
+second-line firmware on both — the 2024 broker and plaintext topic ids — even
+though it reads as 1xx by value. From 200 up the shape stops mattering: the
+second line's own thresholds apply either way, which is why `230.5` is on the
+2025 broker for HMM and still on the 2024 broker for JPLS.
+
 ## HMI firmware lines
 
 The HMI inverters on routes 2 and 4 have the same split, keyed on the numeric
@@ -107,23 +116,41 @@ line it encrypts at any firmware rather than from fw 101.
 The table's numbers reproduce that length rule exactly for whole firmware
 versions, and the shape of the reported version settles the rest: a version like
 `116.5` reads as main-line by value but is five characters, so it is second-line
-firmware and takes the second line's thresholds on both columns. Zeros at either
-end are the one gap: the version reaches the table as a number, so `116.0`
+firmware and takes the second line's thresholds on both columns. The converse
+holds too — `1.5` is three characters, so it is main-line firmware and is
+measured against the main line's thresholds however low it reads, which for a
+TPM-CN means plaintext topic ids rather than the second line's "encrypt at any
+version". Neither line is ever measured against the other's thresholds. Zeros at
+either end are the one gap: the version reaches the table as a number, so `116.0`
 arrives as `116` and `050` as `50`, and each is placed on the line its shortened
 shape implies rather than the one the app would pick.
 
 ## Unverified rows
 
 The broker and topic-id columns of every other row have been checked against the
-app's own code. Two groups have not:
+app's own code, most recently by *executing* it: `marstool app call` runs
+`MqttUtil.isSupportNewMqttCertificate` and the app's per-family version
+controllers out of the shipped snapshot, once per device type and firmware. That
+sweep answered 2,464 broker cells and 962 topic-id cells of this table, and
+disagreed with none of them. What it could not answer:
 
-- **The Venus broker column.** HMG, the VNS models, VAAC2, VEPRO and VDAC pick
-  their broker through a per-device object the app builds at run time, behind a
-  dispatch that neither running the app's code nor reading it resolves. Their
-  topic-id thresholds are confirmed; the broker column is unverified rather than
-  contradicted. All of them sit on `hame-2025` at every firmware except HMG,
-  whose migration at fw 153 is the one value in this group a device could
-  disagree with.
+- **The Venus and HMG broker column.** HMG, `VNSD2`, `VNSA2`, the `VNSE3`
+  models, `VNSE4`, `VNSEMAX`, `VAAC2`, `VEPRO` and `VDAC` pick their broker
+  through a per-device object the app builds at run time, and the rule dies in
+  the app's dependency injection instead of answering for them. Asked directly,
+  each of those per-device objects reports the 2025 broker at any firmware,
+  which is what this table has; the dispatch that picks the object is what stays
+  unconfirmed. HMG is the exception on both counts — its object cannot be asked
+  either — so its migration at fw 153 is the one value in this group a device
+  could disagree with. `VNSG`, `VNSGPV`, `VNSEMINI` and `VNSB` are *not* in this
+  group: the app answers for them, and agrees.
+- **The HMI, HMG and Venus topic-id column.** `CommonHelper.isSupportVid` routes
+  these through that same run-time dispatch, so those thresholds rest on a
+  reading of the app's code rather than on running it. The families whose
+  controllers do answer — HMA/HMB/HMF/HMK/HMJ, the Jupiter models, the HME
+  meters, TPM-CN, TPM2-0 and the SMR readers — are confirmed by execution, and
+  each of them is claimed by exactly one controller, so the dispatch is not in
+  doubt for those.
 - **`VEPRO` and `VDAC`.** The app groups both with the Venus family, while this
   table leaves them to the unknown default. The two agree on the broker and
   differ on topic ids: the default encrypts at any firmware, the Venus rule from

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -137,13 +137,17 @@ disagreed with none of them. What it could not answer:
 - **The Venus and HMG broker column.** HMG, `VNSD2`, `VNSA2`, the `VNSE3`
   models, `VNSE4`, `VNSEMAX`, `VAAC2`, `VEPRO` and `VDAC` pick their broker
   through a per-device object the app builds at run time, and the rule dies in
-  the app's dependency injection instead of answering for them. Asked directly,
-  each of those per-device objects reports the 2025 broker at any firmware,
-  which is what this table has; the dispatch that picks the object is what stays
-  unconfirmed. HMG is the exception on both counts — its object cannot be asked
-  either — so its migration at fw 153 is the one value in this group a device
-  could disagree with. `VNSG`, `VNSGPV`, `VNSEMINI` and `VNSB` are *not* in this
-  group: the app answers for them, and agrees.
+  the app's dependency injection instead of answering for them. Those objects
+  can be reached one at a time, but what they say is thinner than it looks: the
+  `VNSE3`, `VNSE4`, `VNSEMAX` and `VAAC2` objects share a single inherited
+  implementation, which dispatches on the object it is called on, so asking each
+  in turn measures one function four times — and on an object built with no
+  firmware in it, which is the question that matters. `VNSD2` and `VNSA2` sit on
+  a different base and do not answer at all, and HMG's brings the runtime down.
+  So this group's `hame-2025` rests on the reading of the app's code, not on
+  running it, and HMG's migration at fw 153 remains the one value in it a device
+  is most likely to disagree with. `VNSG`, `VNSGPV`, `VNSEMINI` and `VNSB` are
+  *not* in this group: the app answers for them, and agrees.
 - **The HMI, HMG and Venus topic-id column.** `CommonHelper.isSupportVid` routes
   these through that same run-time dispatch, so those thresholds rest on a
   reading of the app's code rather than on running it. The families whose

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -148,6 +148,15 @@ describe("device_matrix", () => {
       test("true again above the main line", () => {
         assert.strictEqual(supportsVid("TPM-CN", "1000"), true);
       });
+      // Three characters puts a version on the main line however low it reads,
+      // and the main line's threshold is the only one it is measured against —
+      // "1.5" is not the second line's "encrypt at any version".
+      test("a three-character version below 101 is main-line plaintext", () => {
+        assert.strictEqual(supportsVid("TPM-CN", "1.5"), false);
+        assert.strictEqual(supportsVid("TPM-CN", "9.9"), false);
+        // Two characters is second-line firmware, which does encrypt.
+        assert.strictEqual(supportsVid("TPM-CN", "50"), true);
+      });
     });
 
     // The app counts characters rather than comparing numbers, so a version
@@ -461,6 +470,24 @@ describe("device_matrix", () => {
       assert.strictEqual(brokerForVersion("HMN-1", 230), "hame-2025");
       // The 1xx line keeps its own thresholds.
       assert.strictEqual(brokerForVersion("JPLS-8H", 199), "hame-2025");
+    });
+
+    // The app reads the firmware line off the shape of the version string once
+    // and answers both questions from it, so a version that is numerically
+    // inside 135-199 but not shaped like a 1xx release is 2xx-line firmware for
+    // the broker exactly as it is for topic ids — and 2xx-line firmware that low
+    // is still on the 2024 broker.
+    test("versions not shaped like 1xx take the 2xx line's broker too", () => {
+      assert.strictEqual(brokerForVersion("HMM-1", "135.5"), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMN-1", "150.5"), "hame-2024");
+      assert.strictEqual(brokerForVersion("JPLS-8H", "199.5"), "hame-2024");
+      // Above 200 the shape no longer decides: the 2xx thresholds apply either
+      // way, and they differ per model.
+      assert.strictEqual(brokerForVersion("HMM-1", "230.5"), "hame-2025");
+      assert.strictEqual(brokerForVersion("JPLS-8H", "230.5"), "hame-2024");
+      assert.strictEqual(brokerForVersion("JPLS-8H", "236.5"), "hame-2025");
+      // A properly shaped 1xx version still migrates at 135.
+      assert.strictEqual(brokerForVersion("HMM-1", "136"), "hame-2025");
     });
 
     test("HME-2/HME-4 main line: hame-2024 below 119, hame-2025 at/above (#145)", () => {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -74,25 +74,30 @@ export interface DeviceProfile {
   /**
    * For families whose firmware runs in two lines, the app reads the line off
    * the *shape* of the raw version string rather than its numeric value, so
-   * {@link vidRoutes} alone cannot place a version like `"150.5"`: it is
-   * numerically inside the first line but is not shaped like one. `shape`
-   * matches the raw versions that really are on the first line, and
-   * `endsBefore` is where the second line starts — below it, a version that
-   * does not match `shape` belongs to the second line and is not encrypted.
+   * the steps alone cannot place a version like `"150.5"`: it is numerically
+   * inside the first line but is not shaped like one. `shape` matches the raw
+   * versions that really are on the first line, and `endsBefore` is where the
+   * second line starts — below it, a version that does not match `shape`
+   * belongs to the second line and is answered from the steps at or above
+   * `endsBefore` alone.
+   *
+   * Like {@link mainLine}, this governs {@link brokerRoutes} and
+   * {@link vidRoutes} alike: the app reads the line once and both of its
+   * answers follow from it. Set this *or* {@link mainLine}.
    */
-  vidFirstLine?: { shape: RegExp; endsBefore: number };
+  firstLine?: { shape: RegExp; endsBefore: number };
   /**
    * The other shape rule, for families whose *off-line* firmware is not simply
    * unencrypted (see the CT entries, where the second line reaches both the
    * 2025 broker and encrypted topic ids from a much lower version than the main
    * one). A raw version that does not match `shape` is answered from the steps
-   * below `startsAt` alone — the second line's own thresholds — instead of from
-   * the whole table.
+   * below `startsAt` alone — the second line's own thresholds; one that does
+   * match is answered from the steps at or above `startsAt`, the main line's
+   * own. Neither line ever sees the other's thresholds, which is what keeps a
+   * main-line version *below* `startsAt` off the second line's steps.
    *
-   * Unlike {@link vidFirstLine}, which only guards topic-id encryption, this
-   * governs {@link brokerRoutes} and {@link vidRoutes} alike, because the app
-   * reads the line once and both of its answers follow from it. Set this *or*
-   * {@link vidFirstLine}.
+   * This governs {@link brokerRoutes} and {@link vidRoutes} alike. Set this
+   * *or* {@link firstLine}.
    */
   mainLine?: { shape: RegExp; startsAt: number };
   /**
@@ -146,9 +151,10 @@ const JUPITER_VID_ROUTES: VidRoute[] = [
 /**
  * `JupiterVersionController.isRelease()` puts a device on the 1xx line only
  * when its raw firmware string is exactly three digits starting with "1" — so
- * "150.5" is *not* on that line even though it sits between 100 and 200.
- * Numbers and 1xx strings agree with the steps above; this only keeps
- * differently shaped versions out of the encrypted 1xx range.
+ * "150.5" is *not* on that line even though it sits between 100 and 200, and
+ * the app answers it from the 2xx line's thresholds on *both* axes: broker as
+ * well as topic ids. Numbers and 1xx strings agree with the steps above; this
+ * only keeps differently shaped versions off the 1xx line.
  */
 const JUPITER_FIRST_LINE = { shape: /^1\d\d$/u, endsBefore: 200 };
 
@@ -213,7 +219,7 @@ function hmeVidRoutes(secondLineVid: number, mainLineVid: number): VidRoute[] {
  * anything below it takes the "supported" branch on both axes — so a two-digit
  * HMI firmware is on the 2025 broker with encrypted topic ids, exactly like the
  * Jupiter and HME second lines. The comparison is numeric (`double.parse`), so
- * no {@link DeviceProfile.vidFirstLine} shape rule is needed here.
+ * no {@link DeviceProfile.firstLine} shape rule is needed here.
  */
 const HMI_MAIN_LINE_START = 100;
 
@@ -416,7 +422,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: startsWith("HMM"),
     brokerRoutes: jupiterBrokerRoutes(230),
     vidRoutes: JUPITER_VID_ROUTES,
-    vidFirstLine: JUPITER_FIRST_LINE,
+    firstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
   {
@@ -424,7 +430,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: startsWith("HMN"),
     brokerRoutes: jupiterBrokerRoutes(230),
     vidRoutes: JUPITER_VID_ROUTES,
-    vidFirstLine: JUPITER_FIRST_LINE,
+    firstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
   {
@@ -432,7 +438,7 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     matches: startsWith("JPLS"),
     brokerRoutes: jupiterBrokerRoutes(232),
     vidRoutes: JUPITER_VID_ROUTES,
-    vidFirstLine: JUPITER_FIRST_LINE,
+    firstLine: JUPITER_FIRST_LINE,
     inverse: "auto",
   },
   // HMD outdoor power stations. The app keys off the sub-type token after the
@@ -618,20 +624,11 @@ export function supportsVid(
   }
   const profile = resolveProfile(type);
   if (profile.vidRoutes) {
-    // Only the raw string carries the shape the app keys off, so check it
-    // before falling back to the numeric steps. A number reaching here keeps
-    // any fractional part the API reported (`main.ts` uses parseFloat) and so
-    // stringifies back to the same shape the app saw.
-    const raw = String(version).trim();
-    const firstLine = profile.vidFirstLine;
-    if (
-      firstLine &&
-      parsed < firstLine.endsBefore &&
-      !firstLine.shape.test(raw)
-    ) {
-      return false;
-    }
-    const routes = onLine(profile.vidRoutes, profile.mainLine, raw);
+    // Only the raw string carries the shape the app keys off, so the line is
+    // picked from it rather than from the numeric steps. A number reaching here
+    // keeps any fractional part the API reported (`main.ts` uses parseFloat) and
+    // so stringifies back to the same shape the app saw.
+    const routes = onLine(profile.vidRoutes, profile, version);
     let supported = false;
     for (const route of routes) {
       if (parsed >= route.since) {
@@ -657,7 +654,7 @@ export function brokerForVersion(
   const profile = resolveProfile(type);
   const routes = onLine(
     profile.brokerRoutes ?? DEFAULT_BROKER_ROUTES,
-    profile.mainLine,
+    profile,
     version,
   );
   const parsed = parseVersion(version);
@@ -671,19 +668,45 @@ export function brokerForVersion(
 }
 
 /**
- * The steps that apply to a version's firmware line. Off the main line only the
- * second line's own steps count, however high the version reads: the app picks
- * the line first and never looks at the other one's thresholds.
+ * The steps that apply to a version's firmware line. The app picks the line
+ * from the raw version string and then never looks at the other line's
+ * thresholds, so neither does this: a version off the main line is answered
+ * from the second line's steps however high it reads, and one on the main line
+ * from the main line's steps however low it reads.
+ *
+ * A family whose table has no step for the chosen line does not distinguish the
+ * lines on that axis at all — TPM-CN is on the 2025 broker either way — so the
+ * whole table stands rather than nothing.
  */
 function onLine<T extends { since: number }>(
   routes: T[],
-  mainLine: DeviceProfile["mainLine"],
+  profile: DeviceProfile,
   version: string | number,
 ): T[] {
-  if (!mainLine || mainLine.shape.test(String(version).trim())) {
-    return routes;
+  const raw = String(version).trim();
+  const { mainLine, firstLine } = profile;
+  if (mainLine) {
+    return keepOrFall(
+      routes,
+      mainLine.shape.test(raw)
+        ? (route) => route.since >= mainLine.startsAt
+        : (route) => route.since < mainLine.startsAt,
+    );
   }
-  return routes.filter((route) => route.since < mainLine.startsAt);
+  if (
+    firstLine &&
+    parseVersion(version) < firstLine.endsBefore &&
+    !firstLine.shape.test(raw)
+  ) {
+    return keepOrFall(routes, (route) => route.since >= firstLine.endsBefore);
+  }
+  return routes;
+}
+
+/** `routes.filter(keep)`, or all of them when that would leave nothing. */
+function keepOrFall<T>(routes: T[], keep: (route: T) => boolean): T[] {
+  const kept = routes.filter((route) => keep(route));
+  return kept.length > 0 ? kept : routes;
 }
 
 /** Whether the remote topic id should be used on the local broker. */


### PR DESCRIPTION
## Summary
Fixed firmware line detection for Jupiter and CT devices when the reported version contains a decimal point. The app determines which firmware line a device is on by examining the *shape* of the version string (e.g., whether it matches a 3-digit pattern), not just its numeric value. This shape-based line determination now correctly applies to both broker selection and topic ID encryption decisions.

## Key Changes
- Renamed `vidFirstLine` to `firstLine` in `DeviceProfile` to clarify that this shape rule governs both broker routes and topic ID encryption, not just topic IDs
- Refactored `onLine()` function to accept the full `DeviceProfile` and properly handle both `mainLine` and `firstLine` shape rules
- Updated line detection logic so versions are consistently evaluated against the correct line's thresholds on both axes (broker and topic IDs)
- Added `keepOrFall()` helper to gracefully fall back to all routes when filtering would leave none (e.g., when a family doesn't distinguish lines on a particular axis)
- Updated documentation and test cases to reflect that shape-based line detection applies uniformly across all routing decisions

## Notable Details
- A version like `150.5` is now correctly identified as second-line firmware for Jupiter devices (HMM, HMN, JPLS) because it doesn't match the 3-digit pattern `/^1\d\d$/`, even though it reads as 1xx numerically
- Similarly, `1.5` on TPM-CN is correctly identified as main-line firmware because it matches the 3-character shape rule, despite reading below the main line threshold
- The line is determined once from the raw version string shape and both broker and topic ID answers follow from that single determination

https://claude.ai/code/session_01HgEM63MzB3cVSnGEKs7h4c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed connectivity and data exchange for Marstek Jupiter devices with decimal-point firmware versions.
  * Fixed data exchange for Marstek TPM-CN meters with short decimal-point firmware versions.
  * Improved firmware-version detection for broker routing and topic identification.

* **Documentation**
  * Updated the device matrix with expanded firmware compatibility and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->