### PR TITLE
Support Venus release-line firmware versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [Next]
+- Fixed Venus devices (including Venus C and Venus E 2.0) whose firmware version contains a decimal point being addressed under the wrong id, and in some cases connecting to the wrong cloud service. Like the Jupiter and meter families, these devices ship a second firmware line that needs different handling
+- Fixed a Marstek CT003 meter reader with an identifier the app does not yet know being given the newest devices' handling, so it exchanged no data
 - Fixed Marstek Jupiter devices (JPLS, HMM, HMN) whose firmware version contains a decimal point connecting to the wrong cloud service, so they exchanged no data at all. Such a version belongs to the second firmware line, which was already handled correctly for how these devices are addressed but not for where they connect
 - Fixed Marstek TPM-CN meters on a short firmware version containing a decimal point exchanging no data in either direction, because the relay addressed them under the wrong id
 - Fixed Marstek `TPM-CN` meters on a two-digit firmware version exchanging no data in either direction, because the relay addressed them under the wrong id. Like the HME meters, TPM-CN ships two firmware lines and the second one needs different handling (#234)

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -35,7 +35,8 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMF                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
 | HMK                 | hame-2024 → hame-2025 @226  | 230   | [226]           | selectable  | |
 | HMJ                 | hame-2024 → hame-2025 @108  | 116   | [108]           | selectable  | |
-| HMG                 | hame-2024 → hame-2025 @153  | 154   | —               | auto        | |
+| HMG (3-char fw)     | hame-2024 → hame-2025 @153  | 154   | —               | auto        | Venus C / Venus E 2.0; see "Venus release line" |
+| HMG (other fw)      | hame-2024 → hame-2025 @153.2| 154.5 | —               | auto        | |
 | HMM (1xx-shaped fw) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | see "Jupiter firmware lines" |
 | HMM (other fw)      | hame-2024 → hame-2025 @230  | 236   | —               | auto        | |
 | HMN (1xx-shaped fw) | hame-2024 → hame-2025 @135  | 136   | —               | auto        | |
@@ -55,6 +56,7 @@ switches to encrypted topic ids, and how forwarding is configured.
 | TPM2-0              | hame-2025                   | 0     | —               | auto        | CT002 new generation (#201) |
 | TPM2 (other)        | hame-2024                   | never | —               | auto        | unrecognised; only `TPM2-0` ships today |
 | SMR-0, SMR-1, SMR-2 | hame-2025                   | 0     | —               | auto        | CT003 meter readers: P1 (NL) / IR (DE) / TIC (FR) |
+| SMR (other)         | hame-2024                   | never | —               | auto        | unrecognised; only those three ship today |
 | HMI-2000, HMI-02KS (fw ≥100)    | hame-2024 → hame-2025 @113  | 105   | —               | auto        | "route 4"; 4-PV microinverter; see "HMI firmware lines" |
 | HMI-2000, HMI-02KS (fw <100)    | hame-2025                   | 0     | —               | auto        | second firmware line |
 | HMI-350, HMI-500    | hame-2024                   | never | —               | auto        | "route 1", incl. `HMI-350S` / `HMI-500S`; see #158 / #164 |
@@ -65,8 +67,10 @@ switches to encrypted topic ids, and how forwarding is configured.
 | HMHL                | hame-2025                   | 0     | —               | auto        | Mars SE |
 | SDH-6K              | hame-2025                   | 0     | —               | auto        | V6000 |
 | HMH, SDH, VENX      | hame-2025                   | never | —               | auto        | Mars, M5000 (other SDH), Venus X |
-| VNSD, VNSA (incl. VNSD2, VNSA2) | hame-2025      | 123   | —               | auto        | Venus series; always 2025 |
-| VNSE3, VNSE3AU, VNSE4, VNSEMAX | hame-2025       | 123   | —               | auto        | Venus series |
+| VNSD, VNSA (incl. VNSD2, VNSA2), 3-char fw | hame-2025 | 123 | —          | auto        | Venus series; always 2025; see "Venus release line" |
+| VNSD, VNSA (incl. VNSD2, VNSA2), other fw  | hame-2025 | 114.8 | —        | auto        | |
+| VNSE3, VNSE3AU, VNSE4, VNSEMAX (3-char fw) | hame-2025 | 123 | —          | auto        | Venus series |
+| VNSE3, VNSE3AU, VNSE4, VNSEMAX (other fw)  | hame-2025 | 114.8 | —        | auto        | |
 | VNSE3US, VNSE3CH    | hame-2025                   | 0     | —               | auto        | Venus series; encrypts unconditionally |
 | VNSGPV              | hame-2024                   | never | —               | auto        | Venus G PV; unlike its VNSG sibling |
 | VNSG, VNSEMINI, VNSB | hame-2025                  | never | —               | auto        | VNS-prefixed but not Venus devices |
@@ -125,51 +129,80 @@ either end are the one gap: the version reaches the table as a number, so `116.0
 arrives as `116` and `050` as `50`, and each is placed on the line its shortened
 shape implies rather than the one the app would pick.
 
+## Venus release line
+
+HMG and the Venus series split the same way, on the same rule: `DeviceInfo`
+`.isRelease` is true when the reported version is exactly three characters, and
+each per-device strategy carries one threshold for that line and another for
+everything else. The two are close together rather than in separate ranges — the
+HMG broker moves at 153 on the release line and at 153.2 off it — so a version
+written with a decimal point is not simply "the same firmware, more precisely":
+it is measured against the other line's number. `153.0` reads as 153 and is
+still on the 2024 broker; `154.0` reads as 154 and still sends plaintext topic
+ids, because off the release line those move at 153.2 and 154.5.
+
+For the Venus topic-id column the two lines are far enough apart that the shape
+decides most of the range: a three-character firmware encrypts from 123, and
+anything else from 114.8. So a Venus E on `122.9` encrypts where the same
+reading on the release line would not. `VNSE3US` and `VNSE3CH` sit above the
+whole rule and encrypt at every firmware.
+
+Only `HmgDevStrategy`, `VNSDDevStrategy` and `VnSe3DevStrategy` carry these
+thresholds in the app. The Venus models whose strategy answers neither question
+(`VNSA`, `VNSD2`, `VNSA2`, `VNSE4`, `VNSEMAX`) are given the same split here on
+the assumption that the family shares it.
+
 ## Unverified rows
 
-The broker and topic-id columns of every other row have been checked against the
-app's own code, most recently by *executing* it: `marstool app call` runs
-`MqttUtil.isSupportNewMqttCertificate` and the app's per-family version
-controllers out of the shipped snapshot, once per device type and firmware. That
-sweep answered 2,464 broker cells and 962 topic-id cells of this table, and
-disagreed with none of them. What it could not answer:
+Every other row's broker and topic-id columns have been checked against the app's
+own code by *executing* it, most recently against Marstek 1.6.72: `marstool app
+call` runs `MqttUtil.isSupportNewMqttCertificate` and the app's per-family
+version controllers out of the shipped snapshot, once per device type and
+firmware. The Venus families, which that route could not reach, are answered by
+building the app's own `DeviceInfo`, asking `DeviceStrategyFactory` for the
+strategy it picks, and calling that strategy directly. Together those sweeps
+answered 2,193 broker cells and 1,653 topic-id cells of this table. They
+disagree with one row, deliberately (see below), and disagreed with the HMG and
+Venus release-line thresholds until this table was corrected to match.
 
-- **The Venus and HMG broker column.** HMG, `VNSD2`, `VNSA2`, the `VNSE3`
-  models, `VNSE4`, `VNSEMAX`, `VAAC2`, `VEPRO` and `VDAC` pick their broker
-  through a per-device object the app builds at run time, and the rule dies in
-  the app's dependency injection instead of answering for them. Those objects
-  can be reached one at a time, but what they say is thinner than it looks: the
-  `VNSE3`, `VNSE4`, `VNSEMAX` and `VAAC2` objects share a single inherited
-  implementation, which dispatches on the object it is called on, so asking each
-  in turn measures one function four times — and on an object built with no
-  firmware in it, which is the question that matters. `VNSD2` and `VNSA2` sit on
-  a different base and do not answer at all, and HMG's brings the runtime down.
-  So this group's `hame-2025` rests on the reading of the app's code, not on
-  running it, and HMG's migration at fw 153 remains the one value in it a device
-  is most likely to disagree with. `VNSG`, `VNSGPV`, `VNSEMINI` and `VNSB` are
-  *not* in this group: the app answers for them, and agrees.
-- **The HMI, HMG and Venus topic-id column.** `CommonHelper.isSupportVid` routes
-  these through that same run-time dispatch, so those thresholds rest on a
-  reading of the app's code rather than on running it. The families whose
-  controllers do answer — HMA/HMB/HMF/HMK/HMJ, the Jupiter models, the HME
-  meters, TPM-CN, TPM2-0 and the SMR readers — are confirmed by execution, and
-  each of them is claimed by exactly one controller, so the dispatch is not in
-  doubt for those.
+What the app still cannot be made to answer:
+
+- **The Venus broker column.** `VNSD`, `VNSA`, `VNSD2`, `VNSA2`, the `VNSE3`
+  models, `VNSE4`, `VNSEMAX`, `VAAC2`, `VEPRO` and `VDAC` reach their broker rule
+  through a per-device strategy object, and none of those objects implements the
+  member the rule ends at — only `HmgDevStrategy` does, which is how HMG's
+  migration at fw 153 is confirmed. So this group's `hame-2025` rests on a
+  reading of the app's code, not on running it. `VNSG`, `VNSGPV`, `VNSEMINI` and
+  `VNSB` are *not* in this group: the factory hands them the unknown-device
+  strategy, so the app answers for them through its own rule, and agrees.
+- **The topic-id column of the Venus models without a strategy of their own.**
+  `VNSA`, `VNSD2`, `VNSA2`, `VNSE4`, `VNSEMAX` and `VAAC2` reach a strategy that
+  does not implement it either. `VNSD` and the `VNSE3` models (`VNSE3US` and
+  `VNSE3CH` included) do, and are confirmed by execution; the rest are given the
+  same numbers on the assumption that the family shares them, and `VAAC2`'s
+  `never` is an assumption in the other direction.
 - **`VEPRO` and `VDAC`.** The app groups both with the Venus family, while this
   table leaves them to the unknown default. The two agree on the broker and
   differ on topic ids: the default encrypts at any firmware, the Venus rule from
-  fw 123. Neither has been observed on a real device, so the default stands
-  until one is.
+  fw 123 (114.8 off the release line). Neither has been observed on a real
+  device, so the default stands until one is.
+- **The _unknown_ row, on purpose.** An id the app does not recognise falls
+  through its broker rule to `false` — the 2024 broker — where this table assumes
+  the 2025 one. Marstek has only added 2025-broker devices since that broker
+  shipped, so the assumption is the better guess for hardware newer than the app
+  build this was checked against, and it is the one row where disagreeing with
+  the app is the point.
 
-The `inverse` column and the AstraMeter placeholder-MAC rule are Hame Relay's
-own handling rather than app behaviour, and cannot be confirmed from the app at
-all.
+The `inverse` column, the `remote-topic-id` column and the AstraMeter
+placeholder-MAC rule are Hame Relay's own handling rather than app behaviour, and
+cannot be confirmed from the app at all.
 
 ## Matching precedence
 
 A device type is matched most-specific first:
 
-1. Exact identifiers — `HME-2`/`HME-4`, `HME-3`/`HME-5`, `TPM-CN`, `TPM2-0`.
+1. Exact identifiers — `HME-2`/`HME-4`, `HME-3`/`HME-5`, `TPM-CN`, `TPM2-0`,
+   `SMR-0`/`SMR-1`/`SMR-2`.
 2. HMI routes, tested in the order 4 → 1 → 2 → 0. The app classifies an HMI id
    by plain **substring**, not by whole token, and checks `2000`/`02KS` before
    `350`/`500` — so `HMI-3500` is route 1 and `HMI-12000` is route 4, not the
@@ -180,8 +213,10 @@ A device type is matched most-specific first:
    - `SDH-6K` before `SDH`.
    - `VNSE3US`/`VNSE3CH` before `VNS`.
    - `VNSGPV` before `VNSG`, and both before `VNS`.
+   - The exact `TPM2-0` and `SMR-0/1/2` ids before their `TPM2` and `SMR`
+     catch-alls, which answer for the ids the app does not recognise.
 4. Base-type prefixes — `HMA`, `HMB`, `HMF`, `HMK`, `HMJ`, `HMG`, `HMM`, `HMN`,
-   `JPLS`, `HMD`, `HME`, `HMH`, `SDH`, `VENX`, `SMR-`, `HMC`, `SCH`, `HML`,
+   `JPLS`, `HMD`, `HME`, `HMH`, `SDH`, `VENX`, `SMR`, `HMC`, `SCH`, `HML`,
    `UB`, `TPM2`, `VNS`, `VAAC2`.
 5. Unknown — assume a `hame-2025`, topic-encryption-capable device.
 

--- a/src/device_matrix.test.ts
+++ b/src/device_matrix.test.ts
@@ -272,18 +272,25 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("HMG - require firmware >= 154.0", () => {
-      test("true at/above 154", () => {
-        assert.strictEqual(supportsVid("HMG", "154.0"), true);
-        assert.strictEqual(supportsVid("HMG", "160.0"), true);
+    describe("HMG - 154 on the release line, 154.5 off it", () => {
+      test("true at/above 154 on the release line", () => {
+        assert.strictEqual(supportsVid("HMG", "154"), true);
+        assert.strictEqual(supportsVid("HMG", "160"), true);
       });
-      test("false below 154", () => {
-        assert.strictEqual(supportsVid("HMG", "153.9"), false);
-        assert.strictEqual(supportsVid("HMG", "150.0"), false);
+      test("false below 154 on the release line", () => {
+        assert.strictEqual(supportsVid("HMG", "153"), false);
+        assert.strictEqual(supportsVid("HMG", "150"), false);
+      });
+      test("a version that is not three characters takes 154.5", () => {
+        // "154.0" reads as 154 but is five characters, so `DeviceInfo.isRelease`
+        // puts it off the release line and it is measured against 154.5.
+        assert.strictEqual(supportsVid("HMG", "154.0"), false);
+        assert.strictEqual(supportsVid("HMG", "154.5"), true);
+        assert.strictEqual(supportsVid("HMG", "1550"), true);
       });
       test("case insensitive", () => {
-        assert.strictEqual(supportsVid("hmg", "154.0"), true);
-        assert.strictEqual(supportsVid("hmg", "153.9"), false);
+        assert.strictEqual(supportsVid("hmg", "154"), true);
+        assert.strictEqual(supportsVid("hmg", "153"), false);
       });
     });
 
@@ -332,26 +339,36 @@ describe("device_matrix", () => {
       });
     });
 
-    describe("Venus series (VNSE3, VNSA, VNSD) - require firmware >= 123.0", () => {
+    describe("Venus series (VNSE3, VNSA, VNSD) - 123 on the release line, 114.8 off it", () => {
       test("true at/above 123", () => {
-        assert.strictEqual(supportsVid("VNSE3", "123.0"), true);
-        assert.strictEqual(supportsVid("VNSA", "135.0"), true);
-        assert.strictEqual(supportsVid("VNSD", "135.0"), true);
+        assert.strictEqual(supportsVid("VNSE3", "123"), true);
+        assert.strictEqual(supportsVid("VNSA", "135"), true);
+        assert.strictEqual(supportsVid("VNSD", "135"), true);
       });
-      test("false below 123", () => {
-        assert.strictEqual(supportsVid("VNSE3", "122.9"), false);
+      test("false below 123 on the release line", () => {
+        assert.strictEqual(supportsVid("VNSE3", "122"), false);
+        assert.strictEqual(supportsVid("VNSE3", "115"), false);
+      });
+      test("a version that is not three characters takes 114.8", () => {
+        // The same shape rule as HMG, with the two lines far enough apart that
+        // it decides most of the range: "122.9" is second-line firmware and
+        // encrypts, where the release line would still be plaintext.
+        assert.strictEqual(supportsVid("VNSE3", "122.9"), true);
+        assert.strictEqual(supportsVid("VNSD", "114.8"), true);
+        assert.strictEqual(supportsVid("VNSD", "114.7"), false);
+        assert.strictEqual(supportsVid("VNSE3", "1150"), true);
       });
       test("case insensitive", () => {
-        assert.strictEqual(supportsVid("vnse3", "123.0"), true);
-        assert.strictEqual(supportsVid("vnsa", "122.9"), false);
+        assert.strictEqual(supportsVid("vnse3", "123"), true);
+        assert.strictEqual(supportsVid("vnsa", "122"), false);
       });
       test("VNSE3US / VNSE3CH encrypt unconditionally", () => {
         assert.strictEqual(supportsVid("VNSE3US", "0"), true);
-        assert.strictEqual(supportsVid("VNSE3US", "122.9"), true);
-        assert.strictEqual(supportsVid("VNSE3CH", "122.9"), true);
-        // VNSE3AU is a plain Venus and keeps the 123 threshold.
-        assert.strictEqual(supportsVid("VNSE3AU", "122.9"), false);
-        assert.strictEqual(supportsVid("VNSE3AU", "123.0"), true);
+        assert.strictEqual(supportsVid("VNSE3US", "122"), true);
+        assert.strictEqual(supportsVid("VNSE3CH", "122"), true);
+        // VNSE3AU is a plain Venus and keeps the release line's 123 threshold.
+        assert.strictEqual(supportsVid("VNSE3AU", "122"), false);
+        assert.strictEqual(supportsVid("VNSE3AU", "123"), true);
       });
       test("VNS-prefixed non-Venus devices never encrypt", () => {
         for (const type of ["VNSG-0", "VNSGPV-0", "VNSEMINI-0", "VNSB-0"]) {
@@ -388,6 +405,11 @@ describe("device_matrix", () => {
         for (const type of ["SMR-0", "SMR-1", "SMR-2"]) {
           assert.strictEqual(supportsVid(type, "0"), true, type);
         }
+      });
+      test("an unrecognized SMR id never encrypts", () => {
+        // The app's CT controller answers for SMR-0/1/2 by name and returns
+        // false for anything else that starts with "SMR-".
+        assert.strictEqual(supportsVid("SMR-3", "999"), false);
       });
     });
 
@@ -449,6 +471,13 @@ describe("device_matrix", () => {
     test("HMG: hame-2024 below 153, hame-2025 at/above", () => {
       assert.strictEqual(brokerForVersion("HMG-50", 152), "hame-2024");
       assert.strictEqual(brokerForVersion("HMG-50", 153), "hame-2025");
+    });
+
+    test("HMG firmware off the release line migrates at 153.2", () => {
+      // Five characters, so `DeviceInfo.isRelease` is false and the app answers
+      // "153.0" from the second line's threshold rather than the release one.
+      assert.strictEqual(brokerForVersion("HMG-50", "153.0"), "hame-2024");
+      assert.strictEqual(brokerForVersion("HMG-50", "153.2"), "hame-2025");
     });
 
     test("HMM/HMN/JPLS: hame-2024 below 135, hame-2025 at/above", () => {
@@ -773,6 +802,13 @@ describe("device_matrix", () => {
       assert.strictEqual(resolveProfile("HME-3").name, "HME-3/HME-5");
       assert.strictEqual(resolveProfile("HME-25").name, "HME");
       assert.strictEqual(resolveProfile("HME-1").name, "HME");
+    });
+
+    test("SMR resolves the three known ids apart from the rest", () => {
+      assert.strictEqual(resolveProfile("SMR-0").name, "SMR (CT003)");
+      assert.strictEqual(resolveProfile("SMR-2").name, "SMR (CT003)");
+      assert.strictEqual(resolveProfile("SMR-3").name, "SMR (other)");
+      assert.strictEqual(resolveProfile("SMR").name, "SMR (other)");
     });
 
     test("TPM2 resolves to its own profile without colliding with TPM-CN", () => {

--- a/src/device_matrix.ts
+++ b/src/device_matrix.ts
@@ -45,6 +45,17 @@ export interface VidRoute {
   supported: boolean;
 }
 
+/**
+ * The tables that answer for firmware off a family's release line: `shape`
+ * matches the versions that are *on* it, and everything else is answered from
+ * whichever of these two the axis needs.
+ */
+export interface OffLine {
+  shape: RegExp;
+  brokerRoutes?: BrokerRoute[];
+  vidRoutes?: VidRoute[];
+}
+
 export interface DeviceProfile {
   /** Stable name for logging/debugging (not used for matching). */
   name: string;
@@ -100,6 +111,19 @@ export interface DeviceProfile {
    * *or* {@link firstLine}.
    */
   mainLine?: { shape: RegExp; startsAt: number };
+  /**
+   * The third shape rule, for families whose two lines have thresholds of their
+   * own rather than ranges of their own. The Venus strategies read the line the
+   * CT meters' way — a three-character version is on the release line — but
+   * their two thresholds sit next to each other (the HMG broker moves at 153 on
+   * the release line and at 153.2 off it), so there is no boundary to split one
+   * table at and the off-line firmware needs a table of its own.
+   *
+   * Like {@link mainLine} and {@link firstLine} this governs both axes at once;
+   * set it instead of either. A table the off line does not name is taken from
+   * the profile, which is how a family that splits on one axis only says so.
+   */
+  offLine?: OffLine;
   /**
    * Exact firmware versions that enable the remote topic id on the local
    * broker. Matched by equality, so a device reporting a fractional version
@@ -171,18 +195,37 @@ const JUPITER_FIRST_LINE = { shape: /^1\d\d$/u, endsBefore: 200 };
 const CT_MAIN_LINE_START = 100;
 
 /**
- * The shape half of that rule. `CtVersionController` counts characters, so a
- * version is on the main line when it is exactly three of them — which for a
- * whole version is the same as the range 100–999 the steps use, and for
- * anything else is not: "116.5" sits inside that range but is five characters,
- * so the app reads it as second-line firmware. Matching on the raw string
- * keeps those with the line the app puts them on.
+ * A firmware version of exactly three characters, which is how two of the app's
+ * controllers tell one of a family's firmware lines from the other. Both count
+ * characters rather than compare numbers, so a version reaches the shorter line
+ * on its shape: "116.5" is five characters however it reads as a number.
  *
  * A version that survives `parseVersion` reaches here with its shape intact,
  * apart from trailing zeros and leading zeros ("116.0", "050"), which the
  * number has already dropped.
  */
-const CT_MAIN_LINE = { shape: /^.{3}$/u, startsAt: CT_MAIN_LINE_START };
+const THREE_CHARACTER_VERSION = /^.{3}$/u;
+
+/**
+ * The shape half of the CT rule. A three-character version is on the main line —
+ * which for a whole version is the same as the range 100–999 the steps use, and
+ * for anything else is not: "116.5" sits inside that range but the app reads it
+ * as second-line firmware. Matching on the raw string keeps those versions with
+ * the line the app puts them on.
+ */
+const CT_MAIN_LINE = {
+  shape: THREE_CHARACTER_VERSION,
+  startsAt: CT_MAIN_LINE_START,
+};
+
+/**
+ * The same three-character rule, for the Venus families. `DeviceInfo.isRelease`
+ * counts characters exactly as `CtVersionController` does, so an HMG or Venus
+ * firmware written with a decimal point ("153.0", "122.9") is off the release
+ * line however it reads as a number, and answers from {@link OffLine} tables of
+ * its own on both axes.
+ */
+const VENUS_RELEASE_LINE = THREE_CHARACTER_VERSION;
 
 /**
  * Broker routing for an HME meter across both of its firmware lines (#212).
@@ -411,10 +454,19 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     inverse: "selectable",
   },
   {
+    // The app reaches HMG through the Venus code (HMG-1/25/50 are Venus C and
+    // Venus E 2.0), so it runs `HmgDevStrategy` and reads the release line off
+    // the shape of the version: 153/154 for a three-character firmware, 153.2
+    // and 154.5 for anything else.
     name: "HMG",
     matches: startsWith("HMG"),
     brokerRoutes: migrate2024to2025(153),
-    vidSupportVersion: 154,
+    vidRoutes: [{ since: 154, supported: true }],
+    offLine: {
+      shape: VENUS_RELEASE_LINE,
+      brokerRoutes: migrate2024to2025(153.2),
+      vidRoutes: [{ since: 154.5, supported: true }],
+    },
     inverse: "auto",
   },
   {
@@ -507,10 +559,22 @@ const DEVICE_PROFILES: DeviceProfile[] = [
   },
   {
     // Marstek CT003 meter readers: SMR-0 (P1, NL), SMR-1 (IR, DE), SMR-2
-    // (TIC, FR).
+    // (TIC, FR). Only those three ids are recognized — see the SMR catch-all
+    // below.
     name: "SMR (CT003)",
-    matches: startsWith("SMR-"),
+    matches: exact("SMR-0", "SMR-1", "SMR-2"),
     vidSupportVersion: 0,
+    inverse: "auto",
+  },
+  {
+    // Any other SMR id is unrecognized by the app's CT controller, which claims
+    // every "SMR-" but answers only for those three: it stays on the 2024
+    // broker and never uses topic encryption. Same shape as the TPM2 pair
+    // above, and wrong on both axes without this entry.
+    name: "SMR (other)",
+    matches: startsWith("SMR"),
+    brokerRoutes: ALWAYS_2024,
+    vidSupportVersion: Infinity,
     inverse: "auto",
   },
   {
@@ -561,9 +625,19 @@ const DEVICE_PROFILES: DeviceProfile[] = [
     // VNSEMAX): always on the 2025 broker, at any firmware — the whole family
     // runs on the 2025 infrastructure and never used the 2024 broker. VEPRO/VDAC
     // do not start with "VNS" and reach the default (also always-2025).
+    //
+    // Topic ids follow the same release-line split as HMG: 123 for a
+    // three-character firmware, 114.8 for anything else. Only the VNSD and
+    // VNSE3 strategies carry that rule in the app; the models whose strategy
+    // answers neither question (VNSA, VNSD2, VNSA2, VNSE4, VNSEMAX) are covered
+    // here on the assumption that the family shares it.
     name: "VNS",
     matches: startsWith("VNS"),
-    vidSupportVersion: 123,
+    vidRoutes: [{ since: 123, supported: true }],
+    offLine: {
+      shape: VENUS_RELEASE_LINE,
+      vidRoutes: [{ since: 114.8, supported: true }],
+    },
     inverse: "auto",
   },
 ];
@@ -623,12 +697,13 @@ export function supportsVid(
     return false;
   }
   const profile = resolveProfile(type);
-  if (profile.vidRoutes) {
+  const { vidRoutes } = offLineTables(profile, version);
+  if (vidRoutes) {
     // Only the raw string carries the shape the app keys off, so the line is
     // picked from it rather than from the numeric steps. A number reaching here
     // keeps any fractional part the API reported (`main.ts` uses parseFloat) and
     // so stringifies back to the same shape the app saw.
-    const routes = onLine(profile.vidRoutes, profile, version);
+    const routes = onLine(vidRoutes, profile, version);
     let supported = false;
     for (const route of routes) {
       if (parsed >= route.since) {
@@ -653,7 +728,7 @@ export function brokerForVersion(
 ): string {
   const profile = resolveProfile(type);
   const routes = onLine(
-    profile.brokerRoutes ?? DEFAULT_BROKER_ROUTES,
+    offLineTables(profile, version).brokerRoutes ?? DEFAULT_BROKER_ROUTES,
     profile,
     version,
   );
@@ -665,6 +740,27 @@ export function brokerForVersion(
     }
   }
   return chosen;
+}
+
+/**
+ * The tables a version is answered from, once {@link DeviceProfile.offLine} has
+ * said which line it is on. A family without that rule, and a version on the
+ * release line, are answered from the profile itself; a table the off line does
+ * not carry falls back to the profile's, so a family that splits on one axis
+ * only leaves the other alone.
+ */
+function offLineTables(
+  profile: DeviceProfile,
+  version: string | number,
+): { brokerRoutes?: BrokerRoute[]; vidRoutes?: VidRoute[] } {
+  const { offLine } = profile;
+  if (!offLine || offLine.shape.test(String(version).trim())) {
+    return profile;
+  }
+  return {
+    brokerRoutes: offLine.brokerRoutes ?? profile.brokerRoutes,
+    vidRoutes: offLine.vidRoutes ?? profile.vidRoutes,
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds support for Venus devices (HMG, VNSD, VNSA, VNSE3, etc.) that use a two-line firmware versioning scheme similar to Jupiter and meter families. Devices report versions with or without decimal points, and the app determines which line they're on by checking if the version string is exactly three characters.

## Changes

- **New `OffLine` interface**: Defines firmware tables for the off-release-line versions, allowing per-axis configuration when a family splits on firmware shape rather than numeric ranges.

- **Updated device profiles**:
  - HMG: Now uses `offLine` to specify different broker (153.2) and topic-id (154.5) thresholds for non-three-character versions
  - VNS (Venus series): Similarly configured with 114.8 topic-id threshold off the release line
  - SMR: Split into exact matches for recognized models (SMR-0/1/2) and a catch-all for unrecognized SMR variants

- **New `offLineTables()` function**: Routes version queries to the appropriate table set based on whether the version matches the release-line shape (three characters).

- **Updated `supportsVid()` and `brokerForVersion()`**: Now consult `offLineTables()` to select the correct thresholds based on firmware line.

- **Documentation**: Added "Venus release line" section explaining the two-line scheme and how it differs from numeric ranges. Updated matching precedence to clarify exact-match priority for SMR variants.

## Notable Details

The release-line detection uses string length (exactly three characters) rather than numeric comparison, matching how the app's `DeviceInfo.isRelease` and `CtVersionController` work. This means "154.0" (five characters) is off the release line despite reading as 154 numerically, and is measured against the off-line threshold (154.5 for HMG).

https://claude.ai/code/session_01W6RERnh3uqoSAccgp9xn6N

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identification and cloud-service assignment for Venus devices using decimal firmware versions.
  * Fixed handling of unknown Marstek CT003 meters so they are classified more accurately and can exchange data.
  * Improved device and broker routing across supported HMG and Venus firmware variants, including firmware release-line differences.

* **Documentation**
  * Updated the device compatibility matrix with revised firmware thresholds, matching rules, and verification details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->