### PR TITLE
Fix device addressing and add cloud connectivity diagnostics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [Next]
+- The startup log now says when a device is not connected to the Marstek cloud. Until now a device that was simply offline looked identical to a misconfigured one: requests were forwarded every minute and nothing ever came back, with nothing in the log to say why (#182)
 - Fixed Venus devices (including Venus C and Venus E 2.0) whose firmware version contains a decimal point being addressed under the wrong id, and in some cases connecting to the wrong cloud service. Like the Jupiter and meter families, these devices ship a second firmware line that needs different handling
 - Fixed a Marstek CT003 meter reader with an identifier the app does not yet know being given the newest devices' handling, so it exchanged no data
 - Fixed Marstek Jupiter devices (JPLS, HMM, HMN) whose firmware version contains a decimal point connecting to the wrong cloud service, so they exchanged no data at all. Such a version belongs to the second firmware line, which was already handled correctly for how these devices are addressed but not for where they connect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # Changelog
 ## [Next]
-- Fixed devices that have been issued an encrypted identifier but have not started using it yet being addressed under an identifier nothing on the other side listens to, so they exchanged no data in either direction while the logs showed requests going out normally. Such a device is now addressed the way the app addresses it (#182)
-- Fixed a device the cloud reports without a MAC address being subscribed to an incomplete topic, which could never carry anything (#182)
-- The startup log now says when a device is not connected to the Marstek cloud. Until now a device that was simply offline looked identical to a misconfigured one: requests were forwarded every minute and nothing ever came back, with nothing in the log to say why (#182)
+- Fixed devices exchanging no data in either direction because the relay addressed them under the wrong id (#182)
+- The log now says when a device is not connected to the cloud, instead of leaving it looking like a broken setup (#182)
 - Fixed Venus devices (including Venus C and Venus E 2.0) whose firmware version contains a decimal point being addressed under the wrong id, and in some cases connecting to the wrong cloud service. Like the Jupiter and meter families, these devices ship a second firmware line that needs different handling
 - Fixed a Marstek CT003 meter reader with an identifier the app does not yet know being given the newest devices' handling, so it exchanged no data
 - Fixed Marstek Jupiter devices (JPLS, HMM, HMN) whose firmware version contains a decimal point connecting to the wrong cloud service, so they exchanged no data at all. Such a version belongs to the second firmware line, which was already handled correctly for how these devices are addressed but not for where they connect

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [Next]
+- Fixed devices that have been issued an encrypted identifier but have not started using it yet being addressed under an identifier nothing on the other side listens to, so they exchanged no data in either direction while the logs showed requests going out normally. Such a device is now addressed the way the app addresses it (#182)
+- Fixed a device the cloud reports without a MAC address being subscribed to an incomplete topic, which could never carry anything (#182)
 - The startup log now says when a device is not connected to the Marstek cloud. Until now a device that was simply offline looked identical to a misconfigured one: requests were forwarded every minute and nothing ever came back, with nothing in the log to say why (#182)
 - Fixed Venus devices (including Venus C and Venus E 2.0) whose firmware version contains a decimal point being addressed under the wrong id, and in some cases connecting to the wrong cloud service. Like the Jupiter and meter families, these devices ship a second firmware line that needs different handling
 - Fixed a Marstek CT003 meter reader with an identifier the app does not yet know being given the newest devices' handling, so it exchanged no data

--- a/src/hame_api.test.ts
+++ b/src/hame_api.test.ts
@@ -1,6 +1,36 @@
 import { test, describe } from "node:test";
 import assert from "node:assert";
-import { readOnlineFlag } from "./hame_api.js";
+import { readOnlineFlag, redactSecrets } from "./hame_api.js";
+
+describe("redactSecrets", () => {
+  // node-fetch puts the whole URL in its error message, which is how the
+  // account's credentials would otherwise reach the log.
+  test("masks the credentials a failed request reports back", () => {
+    const message =
+      "request to https://eu.hamedata.com/ems/api/v1/getDeviceMqttStatus?devid=abc&token=SUPERSECRET failed, reason: getaddrinfo ENOTFOUND";
+    const redacted = redactSecrets(message);
+    assert.ok(!redacted.includes("SUPERSECRET"));
+    assert.ok(redacted.includes("devid=abc"));
+    assert.ok(redacted.includes("token=***"));
+  });
+
+  test("masks the login call's mailbox and password hash", () => {
+    const redacted = redactSecrets(
+      "request to https://eu.hamedata.com/app/Solar/v2_get_device.php?mailbox=user%40example.com&pwd=5f4dcc3b5aa765d61d8327deb882cf99 failed",
+    );
+    assert.ok(!redacted.includes("example.com"));
+    assert.ok(!redacted.includes("5f4dcc3b5aa765d61d8327deb882cf99"));
+    assert.strictEqual(
+      redacted,
+      "request to https://eu.hamedata.com/app/Solar/v2_get_device.php?mailbox=***&pwd=*** failed",
+    );
+  });
+
+  test("leaves a message without credentials alone", () => {
+    const message = "HTTP 503: Service Unavailable";
+    assert.strictEqual(redactSecrets(message), message);
+  });
+});
 
 describe("readOnlineFlag", () => {
   test("reads the values that plainly mean connected", () => {

--- a/src/hame_api.test.ts
+++ b/src/hame_api.test.ts
@@ -1,0 +1,30 @@
+import { test, describe } from "node:test";
+import assert from "node:assert";
+import { readOnlineFlag } from "./hame_api.js";
+
+describe("readOnlineFlag", () => {
+  test("reads the values that plainly mean connected", () => {
+    for (const value of [true, 1, "1", "true", "online", "Connected", " 1 "]) {
+      assert.strictEqual(readOnlineFlag(value), true, `for ${String(value)}`);
+    }
+  });
+
+  test("reads the values that plainly mean not connected", () => {
+    for (const value of [false, 0, "0", "false", "offline", "DISCONNECTED"]) {
+      assert.strictEqual(readOnlineFlag(value), false, `for ${String(value)}`);
+    }
+  });
+
+  // The encoding of this field is not documented, so an unrecognized value has
+  // to stay unknown: reporting it as offline would accuse a device that may
+  // well be connected.
+  test("leaves anything it cannot read unknown", () => {
+    for (const value of [undefined, null, "", "2", 2, -1, {}, [], "maybe"]) {
+      assert.strictEqual(
+        readOnlineFlag(value),
+        undefined,
+        `for ${JSON.stringify(value)}`,
+      );
+    }
+  });
+});

--- a/src/hame_api.ts
+++ b/src/hame_api.ts
@@ -159,6 +159,9 @@ export interface DeviceMqttStatus {
   salt?: string;
 }
 
+/** How long one device's status lookup may take before it is given up on. */
+const STATUS_TIMEOUT_MS = 5000;
+
 interface HameDeviceMqttStatusResponse {
   code: number;
   msg: string;
@@ -304,7 +307,13 @@ export class HameApi {
     url.searchParams.append("token", token);
 
     try {
-      const resp = await fetch(url.toString(), { headers: this.headers });
+      // Bounded, because this runs once per device before the relay starts
+      // forwarding: a cloud that accepts the connection and then never answers
+      // would otherwise hold up startup indefinitely for a diagnostic.
+      const resp = await fetch(url.toString(), {
+        headers: this.headers,
+        signal: AbortSignal.timeout(STATUS_TIMEOUT_MS),
+      });
       if (!resp.ok) {
         logger.debug(
           `Cloud MQTT status for ${devid}: HTTP ${resp.status} ${resp.statusText}`,

--- a/src/hame_api.ts
+++ b/src/hame_api.ts
@@ -51,6 +51,19 @@ function shouldRetryError(error: Error, statusCode?: number): boolean {
   return false;
 }
 
+/**
+ * Masks the credentials that ride in these URLs' query strings. A failed
+ * request reports itself as `request to <full url> failed, reason: ...`, so any
+ * log line carrying an error message from here would otherwise print the
+ * account's token — or, for the login call, the mailbox and password hash.
+ */
+export function redactSecrets(text: string): string {
+  return text.replaceAll(
+    /\b(?<key>token|pwd|mailbox)=[^&\s]*/giu,
+    "$<key>=***",
+  );
+}
+
 async function withRetry<T>(
   operation: () => Promise<T>,
   operationName: string,
@@ -89,7 +102,7 @@ async function withRetry<T>(
 
         const statusInfo = lastStatusCode ? ` (HTTP ${lastStatusCode})` : "";
         logger.warn(
-          `${operationName} failed on attempt ${attempt}/${maxRetries + 1}: ${lastError.message}${statusInfo}. Retrying in ${delay}ms...`,
+          `${operationName} failed on attempt ${attempt}/${maxRetries + 1}: ${redactSecrets(lastError.message)}${statusInfo}. Retrying in ${delay}ms...`,
         );
 
         await new Promise((resolve) => {
@@ -99,11 +112,11 @@ async function withRetry<T>(
         if (attempt <= maxRetries) {
           const statusInfo = lastStatusCode ? ` (HTTP ${lastStatusCode})` : "";
           logger.info(
-            `${operationName} failed with non-retryable error: ${lastError.message}${statusInfo}. Not retrying.`,
+            `${operationName} failed with non-retryable error: ${redactSecrets(lastError.message)}${statusInfo}. Not retrying.`,
           );
         } else {
           logger.error(
-            `${operationName} failed after ${maxRetries + 1} attempts. Final error: ${lastError.message}`,
+            `${operationName} failed after ${maxRetries + 1} attempts. Final error: ${redactSecrets(lastError.message)}`,
           );
         }
         break;
@@ -332,7 +345,7 @@ export class HameApi {
       return body.data;
     } catch (error) {
       logger.debug(
-        `Cloud MQTT status for ${devid} unavailable: ${error instanceof Error ? error.message : String(error)}`,
+        `Cloud MQTT status for ${devid} unavailable: ${redactSecrets(error instanceof Error ? error.message : String(error))}`,
       );
       return undefined;
     }

--- a/src/hame_api.ts
+++ b/src/hame_api.ts
@@ -144,6 +144,54 @@ export interface HameDeviceListResponse {
   }>;
 }
 
+/**
+ * What the cloud knows about a device's own MQTT session, from
+ * `/ems/api/v1/getDeviceMqttStatus`. It answers the question the relay has
+ * whenever a device never replies: is anyone connected on the other side?
+ *
+ * The encoding of these fields is undocumented, so nothing here is interpreted
+ * beyond an unambiguous yes/no — see {@link readOnlineFlag}.
+ */
+export interface DeviceMqttStatus {
+  mqtt?: unknown;
+  ms?: unknown;
+  datetime?: unknown;
+  salt?: string;
+}
+
+interface HameDeviceMqttStatusResponse {
+  code: number;
+  msg: string;
+  data?: DeviceMqttStatus;
+}
+
+/**
+ * `true`/`false` only for values that say so plainly, `undefined` for anything
+ * else. A status we cannot read must not be reported as "offline": that would
+ * turn an unrecognised encoding into a false accusation about the device.
+ */
+export function readOnlineFlag(value: unknown): boolean | undefined {
+  if (typeof value === "boolean") {
+    return value;
+  }
+  if (typeof value === "number") {
+    if (value === 1) {
+      return true;
+    }
+    return value === 0 ? false : undefined;
+  }
+  if (typeof value === "string") {
+    const v = value.trim().toLowerCase();
+    if (v === "1" || v === "true" || v === "online" || v === "connected") {
+      return true;
+    }
+    if (v === "0" || v === "false" || v === "offline" || v === "disconnected") {
+      return false;
+    }
+  }
+  return undefined;
+}
+
 export interface DeviceInfo {
   devid: string;
   name: string;
@@ -151,6 +199,7 @@ export interface DeviceInfo {
   type: string;
   version: string;
   salt?: string; // Optional salt field from device list
+  cloud_mqtt?: DeviceMqttStatus; // Best-effort, from getDeviceMqttStatus
 }
 
 export class HameApi {
@@ -238,6 +287,48 @@ export class HameApi {
     }, "Fetch device list");
   }
 
+  /**
+   * What the cloud says about one device's MQTT session. Best-effort: a device
+   * list that arrived is worth more than this, so every failure here is a debug
+   * line and an undefined result rather than an error.
+   */
+  async fetchDeviceMqttStatus(
+    devid: string,
+    token: string,
+  ): Promise<DeviceMqttStatus | undefined> {
+    const url = new URL(
+      "/ems/api/v1/getDeviceMqttStatus",
+      this.baseUrl.replace(/\/$/u, ""),
+    );
+    url.searchParams.append("devid", devid);
+    url.searchParams.append("token", token);
+
+    try {
+      const resp = await fetch(url.toString(), { headers: this.headers });
+      if (!resp.ok) {
+        logger.debug(
+          `Cloud MQTT status for ${devid}: HTTP ${resp.status} ${resp.statusText}`,
+        );
+        return undefined;
+      }
+
+      const body = (await resp.json()) as HameDeviceMqttStatusResponse;
+      if (body.code !== 1 || !body.data) {
+        logger.debug(
+          `Cloud MQTT status for ${devid}: ${body.code} - ${body.msg}`,
+        );
+        return undefined;
+      }
+
+      return body.data;
+    } catch (error) {
+      logger.debug(
+        `Cloud MQTT status for ${devid} unavailable: ${error instanceof Error ? error.message : String(error)}`,
+      );
+      return undefined;
+    }
+  }
+
   async fetchDevices(mailbox: string, password: string): Promise<DeviceInfo[]> {
     return await withRetry(
       async () => {
@@ -246,7 +337,17 @@ export class HameApi {
         logger.info(
           `Successfully fetched ${list.data.length} devices from Hame API`,
         );
-        return list.data;
+        // Sequential rather than in parallel: this is a startup diagnostic, and
+        // a device list is allowed to be long.
+        const devices: DeviceInfo[] = [];
+        for (const device of list.data) {
+          const cloud_mqtt = await this.fetchDeviceMqttStatus(
+            device.devid,
+            tokenResp.token!,
+          );
+          devices.push(cloud_mqtt ? { ...device, cloud_mqtt } : device);
+        }
+        return devices;
       },
       "Fetch devices from Hame API",
       { maxRetries: 2 }, // Fewer retries for the overall operation since individual calls already retry

--- a/src/main.ts
+++ b/src/main.ts
@@ -333,6 +333,20 @@ async function start() {
       }
       device.broker_id = brokerId;
       if (!device.remote_id) {
+        // The salt pair only sometimes yields a topic id: it also encodes that
+        // no id is in use yet, in which case the app falls back to the
+        // topic-encryption id below rather than hashing what it was given.
+        const saltTopicId =
+          device.salt &&
+          device.version &&
+          supportsVid(device.type, device.version_text ?? device.version)
+            ? CommonHelper.resolveTopicId(device.salt, device.mac, device.type)
+            : undefined;
+        if (saltTopicId && !saltTopicId.id) {
+          logger.debug(
+            `Device ${device.device_id} has no encrypted topic id in use (${saltTopicId.kind}); addressing it by topic encryption instead`,
+          );
+        }
         // Cloud placeholder MACs from AstraMeter are not real firmware: cq/salt
         // paths do not apply; remote topics use the same AES id as other HME.
         // Gate on the HME family too (mirrors the inverse-forwarding check) so a
@@ -353,30 +367,11 @@ async function start() {
           logger.debug(
             `AstraMeter synthetic MAC: remote_id from topic encryption for device ${device.device_id}`,
           );
-        } else if (
-          device.salt &&
-          device.version &&
-          supportsVid(device.type, device.version_text ?? device.version)
-        ) {
+        } else if (saltTopicId?.id) {
+          device.remote_id = saltTopicId.id;
           logger.debug(
-            `Device ${device.device_id} supports CommonHelper.cq method, using salt-based calculation`,
+            `Calculated remote ID using CommonHelper.cq: ${device.remote_id} for device ${device.device_id} (${saltTopicId.kind})`,
           );
-          const firstSalt = CommonHelper.extractFirstSalt(device.salt);
-          if (firstSalt) {
-            device.remote_id = CommonHelper.cq(
-              firstSalt,
-              device.mac,
-              device.type,
-            );
-            logger.debug(
-              `Calculated remote ID using CommonHelper.cq: ${device.remote_id} for device ${device.device_id}`,
-            );
-          } else {
-            logger.warn(
-              `Failed to extract salt for device ${device.device_id}, falling back to alternative method`,
-            );
-            device.remote_id = device.device_id;
-          }
         } else if (broker.topic_encryption_key) {
           logger.debug(
             `Using topic encryption key for device ${device.device_id}`,

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,7 +3,7 @@ import { join, dirname } from "path";
 import { calculateNewVersionTopicId } from "./encryption.js";
 import { HealthServer } from "./health.js";
 import { logger } from "./logger.js";
-import { HameApi, type DeviceInfo } from "./hame_api.js";
+import { HameApi, readOnlineFlag, type DeviceInfo } from "./hame_api.js";
 import {
   MAX_SUBSCRIPTIONS_PER_CONNECTION,
   MQTTForwarder,
@@ -185,6 +185,21 @@ async function start() {
         // pick the wrong broker and strand the device, so fall back to its
         // numeric prefix. Either way, say so rather than routing silently on a
         // version we could not read exactly.
+        // A device with no cloud MQTT session cannot answer anything the relay
+        // forwards, and the symptom — polls going out, nothing coming back —
+        // looks exactly like a topic or broker bug from the logs alone. Say so
+        // here rather than leaving it to be guessed at (#182).
+        const cloudOnline = readOnlineFlag(device.cloud_mqtt?.mqtt);
+        if (cloudOnline === false) {
+          logger.warn(
+            `Device ${device.devid} (${device.type}) is not connected to the Marstek cloud: the relay can forward messages to it, but nothing will come back until the device is online.`,
+          );
+        } else if (device.cloud_mqtt) {
+          logger.debug(
+            `Cloud MQTT status for ${device.devid}: mqtt=${String(device.cloud_mqtt.mqtt)} ms=${String(device.cloud_mqtt.ms)} datetime=${String(device.cloud_mqtt.datetime)}`,
+          );
+        }
+
         const exact = parseVersion(device.version);
         // The numeric prefix is exactly what we want here; `Number` would
         // report NaN for a suffixed version.

--- a/src/topic.test.ts
+++ b/src/topic.test.ts
@@ -156,8 +156,21 @@ describe("CommonHelper", () => {
       assert.notStrictEqual(CommonHelper.cq("0", MAC, TYPE), "");
     });
 
+    // A third value is ignored rather than rejected: only the first two slots
+    // mean anything, and refusing the pair would strand a device that has a
+    // perfectly good id in them.
+    test("reads the first two halves of a longer list", () => {
+      const result = CommonHelper.resolveTopicId(
+        "oldsalt,newsalt,extra",
+        MAC,
+        TYPE,
+      );
+      assert.strictEqual(result.kind, "rotating");
+      assert.strictEqual(result.id, CommonHelper.cq("oldsalt", MAC, TYPE));
+    });
+
     test("reports no id for a pair that carries none", () => {
-      for (const pair of ["salt,", "salt,0", ",", "0,"]) {
+      for (const pair of ["salt,", "salt,0", ",", "0,", ",issued", ",,"]) {
         const result = CommonHelper.resolveTopicId(pair, MAC, TYPE);
         assert.strictEqual(result.id, undefined, `for "${pair}"`);
       }

--- a/src/topic.test.ts
+++ b/src/topic.test.ts
@@ -122,40 +122,67 @@ describe("CommonHelper", () => {
     });
   });
 
-  describe("extractFirstSalt method", () => {
-    test("should extract first salt from comma-separated pair", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt("salt1,salt2"), "salt1");
+  describe("resolveTopicId method", () => {
+    const MAC = "112233445566";
+    const TYPE = "HMI-1";
+
+    test("uses the issued salt when both halves agree", () => {
+      const result = CommonHelper.resolveTopicId(
+        "abc123def456789a,abc123def456789a",
+        MAC,
+        TYPE,
+      );
+      assert.strictEqual(result.kind, "confirmed");
       assert.strictEqual(
-        CommonHelper.extractFirstSalt("first,second,third"),
-        "first",
+        result.id,
+        CommonHelper.cq("abc123def456789a", MAC, TYPE),
       );
     });
 
-    test("should handle single salt value", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt("onlysalt"), "onlysalt");
+    // A rotation in progress: a new salt has been issued, but the device still
+    // answers on the id from the old one until it is told otherwise.
+    test("keeps the old id while the salts differ", () => {
+      const result = CommonHelper.resolveTopicId("oldsalt,newsalt", MAC, TYPE);
+      assert.strictEqual(result.kind, "rotating");
+      assert.strictEqual(result.id, CommonHelper.cq("oldsalt", MAC, TYPE));
     });
 
-    test("should handle salt with whitespace", () => {
-      assert.strictEqual(
-        CommonHelper.extractFirstSalt(" salt1 , salt2 "),
-        "salt1",
-      );
-      assert.strictEqual(
-        CommonHelper.extractFirstSalt("  trimmed  ,  other  "),
-        "trimmed",
-      );
+    // The regression behind #182: hashing the literal "0" yields a plausible
+    // 24-character id that nothing on the cloud is listening to.
+    test("reports no id when the device is not on one yet", () => {
+      const result = CommonHelper.resolveTopicId("0,newsalt", MAC, TYPE);
+      assert.strictEqual(result.kind, "pending");
+      assert.strictEqual(result.id, undefined);
+      assert.notStrictEqual(CommonHelper.cq("0", MAC, TYPE), "");
     });
 
-    test("should return empty string for invalid input", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt(""), "");
-      assert.strictEqual(CommonHelper.extractFirstSalt(null as any), "");
-      assert.strictEqual(CommonHelper.extractFirstSalt(undefined as any), "");
+    test("reports no id for a pair that carries none", () => {
+      for (const pair of ["salt,", "salt,0", ",", "0,"]) {
+        const result = CommonHelper.resolveTopicId(pair, MAC, TYPE);
+        assert.strictEqual(result.id, undefined, `for "${pair}"`);
+      }
     });
 
-    test("should handle edge cases", () => {
-      assert.strictEqual(CommonHelper.extractFirstSalt(",second"), "");
-      assert.strictEqual(CommonHelper.extractFirstSalt("first,"), "first");
-      assert.strictEqual(CommonHelper.extractFirstSalt(","), "");
+    test("reports no id when there is no pair at all", () => {
+      for (const pair of ["", "onlysalt", null as any, undefined as any]) {
+        const result = CommonHelper.resolveTopicId(pair, MAC, TYPE);
+        assert.strictEqual(result.kind, "unusable", `for "${pair}"`);
+        assert.strictEqual(result.id, undefined);
+      }
+    });
+
+    // The cloud has handed out devices with no MAC (#182). cq cannot hash one,
+    // and an empty id would subscribe to a topic with an empty segment.
+    test("reports no id for a MAC too short to hash", () => {
+      const result = CommonHelper.resolveTopicId("salt,salt", "abc", TYPE);
+      assert.strictEqual(result.kind, "unusable");
+      assert.strictEqual(result.id, undefined);
+    });
+
+    test("does not trim, because the app does not either", () => {
+      const padded = CommonHelper.resolveTopicId(" salt , salt ", MAC, TYPE);
+      assert.strictEqual(padded.kind, "confirmed");
+      assert.strictEqual(padded.id, CommonHelper.cq(" salt ", MAC, TYPE));
     });
   });
 });

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -351,7 +351,9 @@ class CommonHelper {
     if (current === "0") {
       return { kind: "pending" };
     }
-    if (issued === "" || issued === "0") {
+    // An empty half is not a salt. Hashing one produces an id as meaningless as
+    // hashing "0" did, so a malformed pair falls back like an absent one.
+    if (current === "" || issued === "" || issued === "0") {
       return { kind: "unusable" };
     }
     if (issued === current) {

--- a/src/topic.ts
+++ b/src/topic.ts
@@ -316,18 +316,64 @@ class CommonHelper {
   }
 
   /**
-   * Extracts the first salt value from a comma-separated salt pair
-   * @param saltPair The comma-separated salt pair (e.g., "salt1,salt2")
-   * @returns The first salt value, or empty string if invalid
+   * What the salt pair says about a device's encrypted topic id.
+   *
+   * - `confirmed`: the device is on the id in `id`.
+   * - `rotating`: a new id has been issued but the device still answers on the
+   *   old one, which is what `id` holds.
+   * - `pending`: an id exists that the device has not taken up. It is only ever
+   *   written to a device over Bluetooth, so this state can last indefinitely.
+   * - `unusable`: the pair carries no id at all.
+   *
+   * The last two have no `id`: the app addresses such a device by its
+   * topic-encryption id instead, and so must we.
    */
-  static extractFirstSalt(saltPair: string): string {
+  static resolveTopicId(
+    saltPair: string,
+    mac: string,
+    vid: string,
+  ): SaltTopicId {
     if (!saltPair || typeof saltPair !== "string") {
-      return "";
+      return { kind: "unusable" };
     }
 
+    // Deliberately not trimmed: the app splits on "," and compares and hashes
+    // the parts as they come, so a padded salt is a different salt there too.
     const parts = saltPair.split(",");
-    return parts.length > 0 ? parts[0].trim() : "";
+    if (parts.length < 2) {
+      return { kind: "unusable" };
+    }
+    const [current, issued] = parts;
+
+    // "0" in the first slot is the app's "no id in use yet", whatever the
+    // second slot holds. Hashing that literal is what produced a plausible but
+    // meaningless topic id, and a device that never answers (#182).
+    if (current === "0") {
+      return { kind: "pending" };
+    }
+    if (issued === "" || issued === "0") {
+      return { kind: "unusable" };
+    }
+    if (issued === current) {
+      return withId({ kind: "confirmed" }, CommonHelper.cq(issued, mac, vid));
+    }
+    return withId({ kind: "rotating" }, CommonHelper.cq(current, mac, vid));
   }
+}
+
+/** How a device's encrypted topic id stands, per {@link CommonHelper.resolveTopicId}. */
+export interface SaltTopicId {
+  kind: "confirmed" | "rotating" | "pending" | "unusable";
+  id?: string;
+}
+
+/**
+ * `cq` answers with an empty string for a MAC too short to hash — a device the
+ * cloud reported without one. An id of "" would subscribe to a topic with an
+ * empty segment, so treat it as no id and let the caller fall back (#182).
+ */
+function withId(result: SaltTopicId, id: string): SaltTopicId {
+  return id ? { ...result, id } : { kind: "unusable" };
 }
 
 export { StreamUtil, CodeUtil, HexUtil, CommonHelper };


### PR DESCRIPTION
## Summary

This PR fixes a critical issue where devices were not exchanging data because the relay was addressing them under incorrect topic IDs. It also adds cloud connectivity diagnostics to help identify when devices are offline.

## Key Changes

- **Fixed salt pair handling**: Replaced `extractFirstSalt()` with `resolveTopicId()` that properly interprets the salt pair encoding, including handling the "0" sentinel value that indicates no ID is in use yet. This fixes #182 where devices with pending IDs were being addressed under meaningless topic IDs.

- **Added cloud MQTT status checking**: New `fetchDeviceMqttStatus()` API call queries the cloud for each device's MQTT session status during startup, providing visibility into whether devices are actually connected to the cloud.

- **Added online status interpretation**: New `readOnlineFlag()` function safely interprets various encodings of online/offline status (boolean, numeric, string variants) while returning `undefined` for unrecognized values to avoid false accusations of offline devices.

- **Enhanced device diagnostics**: The startup log now explicitly warns when a device is not connected to the cloud, and logs the raw cloud MQTT status for debugging. This makes it immediately clear when connectivity issues are device-side rather than relay-side.

- **Improved salt pair state tracking**: `SaltTopicId` interface now distinguishes between four states: `confirmed` (device is on the issued ID), `rotating` (new ID issued but device still on old one), `pending` (ID issued but not yet deployed to device), and `unusable` (no valid ID available).

## Implementation Details

- Cloud MQTT status is fetched sequentially during startup (not in parallel) to avoid overwhelming the API for large device lists.
- The salt pair is deliberately not trimmed during parsing to match the app's behavior exactly.
- Empty string topic IDs from `cq()` hashing are treated as unusable to prevent subscribing to malformed topics.
- All cloud API failures are logged at debug level and treated as non-fatal, allowing the relay to continue operating with degraded diagnostics.

https://claude.ai/code/session_0176HRYozu3pYRRTYQubGUR2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed device communication when remote identifiers are resolved incorrectly.
  - Improved handling of devices without an active cloud connection, avoiding misleading setup failures.
  - Added support for changing or pending connection identifiers.

- **Diagnostics**
  - Logs now clearly indicate when a device is offline from the cloud.
  - Cloud connection details are recorded for connected devices.

- **Tests**
  - Added coverage for online-status detection and remote identifier resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->